### PR TITLE
Remove road edge alignment and update WOD-Motion doc

### DIFF
--- a/docs/datasets/wod_motion.rst
+++ b/docs/datasets/wod_motion.rst
@@ -54,6 +54,9 @@ Available Modalities
    * - Traffic Lights
      - ✓
      - Traffic lights include the status and the lane id they are associated with, see :class:`~py123d.datatypes.detections.TrafficLightDetections`.
+   * - Custom
+     - ✓
+     - WOD-Motion scenario metadata is available through the ``aux`` custom modality.
    * - Cameras
      - X
      - n/a
@@ -67,6 +70,32 @@ Available Modalities
   .. autoclass:: py123d.parser.registry.WODMotionBoxDetectionLabel
     :members:
     :no-inherited-members:
+
+
+Custom Metadata
+~~~~~~~~~~~~~~~
+
+WOD-Motion conversion writes scenario-level prediction metadata to the ``aux`` custom modality:
+
+.. code-block:: python
+
+  aux_metadata = scene.get_all_custom_modality_metadatas()["aux"].metadata
+
+Per-timestep auxiliary data is available through the same modality id:
+
+.. code-block:: python
+
+  aux_data = scene.get_custom_modality_at_iteration(i, "aux").data
+
+The ``aux`` metadata contains:
+
+* ``objects_of_interest``
+* ``tracks_to_predict``
+* ``track_index_to_token``
+* ``track_token_to_object_type``
+* ``current_time_index``
+* ``sdc_track_index``
+* ``scenario_variant``
 
 
 Download

--- a/src/py123d/api/map/arrow/arrow_map_writer.py
+++ b/src/py123d/api/map/arrow/arrow_map_writer.py
@@ -29,7 +29,6 @@ from py123d.datatypes import (
 )
 from py123d.datatypes.map_objects.base_map_objects import BaseMapObject
 from py123d.geometry import Polyline2D, Polyline3D
-from py123d.parser.utils.map_utils.road_edge.road_edge_2d_utils import align_road_edges_to_traffic
 
 
 class ArrowMapWriter(BaseMapWriter):
@@ -174,12 +173,6 @@ class ArrowMapWriter(BaseMapWriter):
 
             if not self._map_file.parent.exists():
                 self._map_file.parent.mkdir(parents=True, exist_ok=True)
-
-            if MapLayer.LANE in self._map_data and MapLayer.ROAD_EDGE in self._map_data:
-                self._map_data[MapLayer.ROAD_EDGE]["wkb"] = align_road_edges_to_traffic(
-                    self._map_data[MapLayer.LANE]["centerline"],
-                    self._map_data[MapLayer.ROAD_EDGE]["wkb"],
-                )
 
             # NOTE @DanielDauner: Currently, we enforce remapping of map IDs to integers for Arrow maps.
             # In the future, string IDs could be supported as well, but this complicates the implementation and

--- a/src/py123d/parser/utils/map_utils/road_edge/road_edge_2d_utils.py
+++ b/src/py123d/parser/utils/map_utils/road_edge/road_edge_2d_utils.py
@@ -71,40 +71,6 @@ def split_line_geometry_by_max_length(
     return all_segments
 
 
-def align_road_edges_to_traffic(centerlines: List[np.ndarray], road_edge_wkbs: List[bytes]) -> List[bytes]:
-    """Flip road edge polylines so they follow traffic direction (nearest lane centerline).
-
-    :param centerlines: Lane centerlines as numpy arrays of shape (N, 2+).
-    :param road_edge_wkbs: Road edge geometries as WKB bytes.
-    :return: WKB bytes with misaligned road edges reversed.
-    """
-    if not centerlines or not road_edge_wkbs:
-        return road_edge_wkbs
-
-    cl_midpoints = np.array([cl[:, :2].mean(axis=0) for cl in centerlines])
-    cl_directions = np.array([cl[-1, :2] - cl[0, :2] for cl in centerlines])
-
-    result = []
-    for wkb in road_edge_wkbs:
-        geom = shapely.from_wkb(wkb)
-        coords = np.array(geom.coords)
-        if len(coords) < 2:
-            result.append(wkb)
-            continue
-
-        re_dir = coords[-1, :2] - coords[0, :2]
-        if np.linalg.norm(re_dir) == 0:
-            result.append(wkb)
-            continue
-
-        re_mid = coords[:, :2].mean(axis=0)
-        nearest_idx = np.argmin(np.linalg.norm(cl_midpoints - re_mid, axis=1))
-        dot = np.dot(re_dir, cl_directions[nearest_idx])
-        result.append(shapely.reverse(geom).wkb if dot <= 0 else wkb)
-
-    return result
-
-
 def split_polygon_by_grid(polygon: Polygon, cell_size: float) -> List[Polygon]:
     """
     Split a polygon by grid-like cells of given size.


### PR DESCRIPTION
This pull request makes two main types of changes: it updates the documentation for the WOD-Motion dataset to describe the new "aux" custom modality for scenario metadata, and it removes the `align_road_edges_to_traffic` utility and its usage from the codebase.

The current `align_road_edges_to_traffic` create bugs in the map representation so it is preferable to leave the road edge convention choice to the end user.