### PR TITLE
Add Griffin drone-side (UAV) dataset parser

### DIFF
--- a/docs/datasets/griffin.rst
+++ b/docs/datasets/griffin.rst
@@ -13,9 +13,12 @@ cameras, the 80-beam top LiDAR, ego poses, and 3D boxes. Each scene becomes one 
 routed to its official ``train`` / ``val`` partition.
 
 .. note::
-  The drone-side and cooperative (vehicle + drone) perspectives are not yet converted.
-  The 123D log abstraction models a single agent per log; cooperative support is a planned
-  follow-up that the vehicle-side conversion lays the groundwork for.
+  The **drone-side** (UAV) agent is also available as a *separate single-agent* conversion
+  (``dataset=griffin_drone``): five pinhole cameras (four cardinal + one nadir), ego poses, and
+  3D boxes, with aerial state (UAV flag, per-frame altitude) in a custom modality. The drone
+  carries no LiDAR. True first-class cooperation (vehicle + drone with cross-agent transforms
+  as a core datatype) remains a design-first follow-up; the vehicle and drone logs of a scene
+  already share one global (ENU) frame, so they can be aligned by scene id + timestamp.
 
 .. dropdown:: Overview
   :open:
@@ -169,8 +172,10 @@ Dataset Issues
   parser lifts boxes to the global frame and keeps LiDAR points ego-relative.
 * **Labels:** Non-traffic CARLA categories (e.g. military props) are outside the Griffin
   perception taxonomy and are skipped during conversion.
-* **Drone / cooperative:** Only the vehicle-side is converted; drone-side and cooperative
-  perspectives are not yet supported.
+* **Drone-side:** Converted separately (``dataset=griffin_drone``) as a single-agent UAV log:
+  5 cameras incl. a nadir ``bottom`` camera (:class:`~py123d.datatypes.sensors.CameraID.PCAM_D0`),
+  no LiDAR, and aerial state in a :class:`~py123d.datatypes.custom.CustomModality` (id ``aerial``).
+  Cooperative (joint vehicle + drone) perspectives are not modelled as a first-class type yet.
 
 Citation
 ~~~~~~~~

--- a/src/py123d/datatypes/sensors/base_camera.py
+++ b/src/py123d/datatypes/sensors/base_camera.py
@@ -81,6 +81,9 @@ class CameraID(SerialIntEnum):
     PCAM_STEREO_R = 9
     """Right pinhole stereo camera."""
 
+    PCAM_D0 = 19
+    """Nadir (downward-looking) pinhole camera, e.g. a UAV's bottom camera."""
+
     # Fisheye MEI cameras
     # ------------------------------------------------------------------------------------------------------------------
 
@@ -126,6 +129,7 @@ ALL_PINHOLE_CAMERA_IDS = [
     CameraID.PCAM_R2,
     CameraID.PCAM_STEREO_L,
     CameraID.PCAM_STEREO_R,
+    CameraID.PCAM_D0,
 ]
 
 ALL_FISHEYE_MEI_CAMERA_IDS = [

--- a/src/py123d/parser/griffin/griffin_drone_parser.py
+++ b/src/py123d/parser/griffin/griffin_drone_parser.py
@@ -1,0 +1,353 @@
+"""Drone-side parser for the Griffin aerial-ground cooperative dataset.
+
+This parser converts the **UAV (drone)** agent of Griffin as a *second
+single-agent log* (Path 1): five pinhole cameras (four cardinal + one nadir),
+ego poses, and 3D box annotations. It deliberately mirrors the shape of the
+vehicle-side :class:`~py123d.parser.griffin.griffin_parser.GriffinParser`, with
+three agent-specific differences:
+
+1. **No LiDAR.** Griffin equips only the ground vehicle with a LiDAR; the drone
+   is camera-only (``use_lidar=False`` in the official drone-side configs).
+2. **A nadir camera.** The drone adds a downward-looking ``bottom`` camera
+   (mapped to :class:`~py123d.datatypes.sensors.CameraID.PCAM_D0`) on top of the
+   four cardinal cameras.
+3. **Aerial state in a custom modality.** "This ego is a UAV" plus the per-frame
+   altitude are emitted via :class:`~py123d.datatypes.custom.CustomModality`
+   rather than overloading the core ego/sensor types.
+
+Because boxes and cameras are lifted to a shared global (ENU) world frame for
+both agents, the vehicle and drone logs of the same scene land in one coordinate
+system automatically; a downstream user aligns them by scene id + timestamp.
+True first-class cooperation (cross-agent transforms as a core datatype) is a
+separate, design-first follow-up (Path 2) and is intentionally out of scope.
+
+References
+----------
+.. [1] Wang et al., "Griffin: Aerial-Ground Cooperative Detection and Tracking
+   Dataset and Benchmark", arXiv preprint 2503.06983 (2025).
+.. [2] Official toolkit: https://github.com/wang-jh18-SVM/Griffin
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib import resources
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Union
+
+from py123d.datatypes import (
+    BoxDetectionAttributes,
+    BoxDetectionSE3,
+    BoxDetectionsSE3,
+    CameraID,
+    EgoStateSE3,
+    LogMetadata,
+    PinholeCameraMetadata,
+    PinholeDistortion,
+    PinholeIntrinsics,
+    Timestamp,
+)
+from py123d.datatypes.custom.custom_modality import CustomModality, CustomModalityMetadata
+from py123d.geometry import BoundingBoxSE3, PoseSE3
+from py123d.geometry.transform import rel_to_abs_se3
+from py123d.parser.base_dataset_parser import (
+    BaseDatasetParser,
+    BaseLogParser,
+    BaseMapParser,
+    ModalitiesSync,
+    ParsedCamera,
+)
+from py123d.parser.griffin.utils.griffin_constants import (
+    GRIFFIN_BOX_DETECTION_FROM_STR,
+    GRIFFIN_BOX_DETECTIONS_SE3_METADATA,
+    GRIFFIN_CAMERA_HEIGHT,
+    GRIFFIN_CAMERA_PERIOD_US,
+    GRIFFIN_CAMERA_WIDTH,
+    GRIFFIN_DRONE_AERIAL_MODALITY_ID,
+    GRIFFIN_DRONE_AERIAL_STATIC_METADATA,
+    GRIFFIN_DRONE_CAMERA_MAPPING,
+    GRIFFIN_SPLITS,
+    build_griffin_drone_ego_metadata,
+    split_to_subset_and_kind,
+)
+from py123d.parser.griffin.utils.griffin_utils import (
+    ego_box_to_global_se3,
+    load_calibration,
+    load_scene_index,
+    load_split_scene_names,
+    parse_label_file,
+    pose_dict_to_ego_to_global_se3,
+    read_json,
+)
+
+logger = logging.getLogger(__name__)
+
+# Zero distortion: Griffin renders ideal pinhole cameras in CARLA.
+_GRIFFIN_PINHOLE_DISTORTION = PinholeDistortion(k1=0.0, k2=0.0, p1=0.0, p2=0.0, k3=0.0)
+
+
+def _default_split_file(subset: str) -> Path:
+    """Resolve the embedded official split file for ``subset``.
+
+    The drone side reuses the *same* official train/val partitions as the
+    vehicle side: Griffin's split files assign scenes by name, agent-agnostically.
+
+    :param subset: Subset name, e.g. ``"griffin_50scenes_25m"``.
+    :return: Path to the packaged ``splits/{subset}.json``.
+    """
+    return Path(str(resources.files("py123d.parser.griffin").joinpath("splits", f"{subset}.json")))
+
+
+class GriffinDroneParser(BaseDatasetParser):
+    """Dataset parser for the Griffin dataset (drone-side, single agent)."""
+
+    def __init__(
+        self,
+        splits: List[str],
+        griffin_data_root: Union[Path, str],
+        split_data_root: Optional[Union[Path, str]] = None,
+    ) -> None:
+        """Initialize the :class:`GriffinDroneParser`.
+
+        :param splits: Splits to convert, e.g. ``["griffin_50scenes_25m_train"]``.
+            Each split's subset prefix selects the ``griffin-release`` tree and
+            the official train/val partition.
+        :param griffin_data_root: Directory containing the subset folders, laid
+            out as ``{griffin_data_root}/{subset}/griffin-release/drone-side``
+            (the official ``datasets`` directory).
+        :param split_data_root: Optional directory holding ``{subset}.json`` split
+            files. When ``None``, the official split files embedded in this
+            package are used.
+        """
+        for split in splits:
+            assert split in GRIFFIN_SPLITS, f"Split {split} is not available. Available splits: {GRIFFIN_SPLITS}"
+
+        self._splits: List[str] = list(splits)
+        self._griffin_data_root: Path = Path(griffin_data_root)
+        self._split_data_root: Optional[Path] = Path(split_data_root) if split_data_root is not None else None
+
+    def _split_file(self, subset: str) -> Path:
+        """Return the split file for ``subset`` (override directory or embedded)."""
+        if self._split_data_root is not None:
+            return self._split_data_root / f"{subset}.json"
+        return _default_split_file(subset)
+
+    def _drone_root(self, subset: str) -> Path:
+        """Return the ``drone-side`` directory for ``subset``."""
+        return self._griffin_data_root / subset / "griffin-release" / "drone-side"
+
+    def get_log_parsers(self) -> List[GriffinDroneLogParser]:  # type: ignore[override]
+        """Inherited, see superclass. One log per scene, routed to its split partition."""
+        log_parsers: List[GriffinDroneLogParser] = []
+        for split in self._splits:
+            subset, kind = split_to_subset_and_kind(split)
+            drone_root = self._drone_root(subset)
+            if not drone_root.is_dir():
+                logger.warning("Griffin subset '%s' not found at %s; skipping split '%s'.", subset, drone_root, split)
+                continue
+
+            scene_index = load_scene_index(drone_root)
+            wanted_scenes = set(load_split_scene_names(self._split_file(subset), kind))
+            scene_frames = {name: frames for name, frames in scene_index}
+
+            missing = wanted_scenes - set(scene_frames)
+            if missing:
+                logger.warning(
+                    "Split '%s' lists %d scene(s) absent from %s/scene_infos.json (e.g. %s).",
+                    split,
+                    len(missing),
+                    drone_root,
+                    sorted(missing)[0],
+                )
+
+            for scene_name, frames in scene_index:
+                if scene_name not in wanted_scenes or not frames:
+                    continue
+                log_parsers.append(
+                    GriffinDroneLogParser(
+                        griffin_data_root=self._griffin_data_root,
+                        subset=subset,
+                        scene_name=scene_name,
+                        frames=frames,
+                        split=split,
+                    )
+                )
+        return log_parsers
+
+    def get_map_parsers(self) -> List[BaseMapParser]:
+        """Inherited, see superclass. Griffin provides no HD map."""
+        return []
+
+
+class GriffinDroneLogParser(BaseLogParser):
+    """Lightweight, picklable handle to one Griffin scene (drone-side)."""
+
+    def __init__(
+        self,
+        griffin_data_root: Path,
+        subset: str,
+        scene_name: str,
+        frames: List[str],
+        split: str,
+    ) -> None:
+        """Initialize the log parser.
+
+        :param griffin_data_root: Directory containing the subset folders.
+        :param subset: Subset name, e.g. ``"griffin_50scenes_25m"``.
+        :param scene_name: Full scene identifier, e.g. ``scene-0026-Town07-001``.
+        :param frames: Ordered 6-digit frame ids belonging to this scene.
+        :param split: Owning split name.
+        """
+        self._griffin_data_root = griffin_data_root
+        self._subset = subset
+        self._scene_name = scene_name
+        self._frames = frames
+        self._split = split
+
+        # ``{subset}/griffin-release`` is the sensor-root-relative prefix used for
+        # all stored camera relative paths, so they resolve from a single
+        # ``get_sensor_root("griffin") == griffin_data_root`` at read time.
+        self._release_rel = Path(subset) / "griffin-release"
+        self._drone_root = griffin_data_root / self._release_rel / "drone-side"
+        self._calib_dir = self._drone_root / "calib"
+
+    def get_log_metadata(self) -> LogMetadata:
+        """Inherited, see superclass."""
+        return LogMetadata(
+            dataset="griffin",
+            split=self._split,
+            log_name=self._scene_name,
+            location=self._subset,
+        )
+
+    def _build_camera_metadata(self) -> Dict[CameraID, PinholeCameraMetadata]:
+        """Build pinhole camera metadata from the static per-camera calibration files."""
+        camera_metadata: Dict[CameraID, PinholeCameraMetadata] = {}
+        for camera_name, camera_id in GRIFFIN_DRONE_CAMERA_MAPPING.items():
+            intrinsic, extrinsic = load_calibration(self._calib_dir, camera_name)
+            assert intrinsic is not None, f"Missing intrinsics for Griffin drone camera '{camera_name}'."
+            camera_metadata[camera_id] = PinholeCameraMetadata(
+                camera_name=camera_name,
+                camera_id=camera_id,
+                intrinsics=PinholeIntrinsics(
+                    fx=float(intrinsic[0, 0]),
+                    fy=float(intrinsic[1, 1]),
+                    cx=float(intrinsic[0, 2]),
+                    cy=float(intrinsic[1, 2]),
+                ),
+                distortion=_GRIFFIN_PINHOLE_DISTORTION,
+                width=GRIFFIN_CAMERA_WIDTH,
+                height=GRIFFIN_CAMERA_HEIGHT,
+                # Griffin's extrinsic is sensor-to-ego; the ego frame is the IMU
+                # frame in 123D, so it maps directly to camera_to_imu_se3. For the
+                # drone, the gimbal/mount orientation is baked into this extrinsic.
+                camera_to_imu_se3=PoseSE3.from_transformation_matrix(extrinsic),
+                is_undistorted=True,
+            )
+        return camera_metadata
+
+    def iter_modalities_sync(self) -> Iterator[ModalitiesSync]:
+        """Inherited, see superclass."""
+        ego_metadata = build_griffin_drone_ego_metadata()
+        camera_metadata = self._build_camera_metadata()
+        aerial_metadata = CustomModalityMetadata(
+            modality_id=GRIFFIN_DRONE_AERIAL_MODALITY_ID,
+            metadata=dict(GRIFFIN_DRONE_AERIAL_STATIC_METADATA),
+        )
+
+        for frame in self._frames:
+            timestamp = Timestamp.from_us(int(frame) * GRIFFIN_CAMERA_PERIOD_US)
+
+            ego_pose = read_json(self._drone_root / "pose" / f"{frame}.json")
+            ego_to_global = pose_dict_to_ego_to_global_se3(ego_pose)
+            ego_state = EgoStateSE3.from_imu(
+                imu_se3=ego_to_global,
+                metadata=ego_metadata,
+                timestamp=timestamp,
+                dynamic_state_se3=None,
+            )
+
+            box_detections = self._extract_box_detections(frame, timestamp, ego_to_global)
+            parsed_cameras = self._extract_cameras(frame, timestamp, ego_to_global, camera_metadata)
+            aerial_state = self._extract_aerial_state(ego_pose, timestamp, aerial_metadata)
+
+            yield ModalitiesSync(
+                timestamp=timestamp,
+                modalities=[ego_state, box_detections, *parsed_cameras, aerial_state],
+            )
+
+    def _extract_box_detections(self, frame: str, timestamp: Timestamp, ego_to_global: PoseSE3) -> BoxDetectionsSE3:
+        """Extract 3D box detections for a frame, lifted from the drone ego to the global frame."""
+        annotations = parse_label_file(self._drone_root / "label" / f"{frame}.txt")
+
+        box_detections: List[BoxDetectionSE3] = []
+        for annotation in annotations:
+            label = GRIFFIN_BOX_DETECTION_FROM_STR.get(annotation["type"].lower())
+            if label is None:
+                # Non-traffic categories (e.g. CARLA military props) are outside
+                # the Griffin perception taxonomy; skip rather than mislabel.
+                logger.debug("Skipping unrecognized Griffin category '%s'.", annotation["type"])
+                continue
+
+            bounding_box = BoundingBoxSE3(
+                center_se3=ego_box_to_global_se3(annotation, ego_to_global),
+                length=annotation["l"],
+                width=annotation["w"],
+                height=annotation["h"],
+            )
+            box_detections.append(
+                BoxDetectionSE3(
+                    attributes=BoxDetectionAttributes(label=label, track_token=annotation["track_id"]),
+                    bounding_box_se3=bounding_box,
+                    velocity_3d=None,
+                )
+            )
+
+        return BoxDetectionsSE3(
+            box_detections=box_detections,
+            timestamp=timestamp,
+            metadata=GRIFFIN_BOX_DETECTIONS_SE3_METADATA,
+        )
+
+    def _extract_cameras(
+        self,
+        frame: str,
+        timestamp: Timestamp,
+        ego_to_global: PoseSE3,
+        camera_metadata: Dict[CameraID, PinholeCameraMetadata],
+    ) -> List[ParsedCamera]:
+        """Reference all available camera images for a frame, with global camera poses."""
+        parsed_cameras: List[ParsedCamera] = []
+        for camera_name, camera_id in GRIFFIN_DRONE_CAMERA_MAPPING.items():
+            relative_path = self._release_rel / "drone-side" / "camera" / camera_name / f"{frame}.png"
+            absolute_path = self._griffin_data_root / relative_path
+            if not absolute_path.exists():
+                continue
+            camera_to_global_se3 = rel_to_abs_se3(
+                origin=ego_to_global,
+                pose_se3=camera_metadata[camera_id].camera_to_imu_se3,
+            )
+            parsed_cameras.append(
+                ParsedCamera(
+                    metadata=camera_metadata[camera_id],
+                    timestamp=timestamp,
+                    camera_to_global_se3=camera_to_global_se3,
+                    dataset_root=self._griffin_data_root,
+                    relative_path=str(relative_path),
+                )
+            )
+        return parsed_cameras
+
+    def _extract_aerial_state(
+        self, ego_pose: Dict[str, float], timestamp: Timestamp, aerial_metadata: CustomModalityMetadata
+    ) -> CustomModality:
+        """Emit aerial-specific per-frame state for the UAV ego.
+
+        Altitude is the ENU ``z`` of the drone ego pose (metres). The static
+        "this ego is a UAV" facts live in ``aerial_metadata``; here we carry only
+        what varies per frame.
+        """
+        aerial_data = {
+            "altitude_m": float(ego_pose["z"]),
+        }
+        return CustomModality(data=aerial_data, metadata=aerial_metadata, timestamp=timestamp)

--- a/src/py123d/parser/griffin/utils/griffin_constants.py
+++ b/src/py123d/parser/griffin/utils/griffin_constants.py
@@ -21,7 +21,7 @@ References
 
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from py123d.datatypes.detections.box_detections_metadata import BoxDetectionsSE3Metadata
 from py123d.datatypes.sensors.base_camera import CameraID
@@ -141,3 +141,69 @@ def build_griffin_ego_metadata():
             rear_axle_to_imu_se3=PoseSE3.identity(),
         )
     return _GRIFFIN_EGO_STATE_SE3_METADATA
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Drone (UAV) side
+# ----------------------------------------------------------------------------------------------------------------------
+
+# Drone-side cameras: the four cardinal cameras plus a downward-looking (nadir)
+# ``bottom`` camera, mapped onto pinhole ids. The dict keys are the on-disk
+# directory and calibration names. Unlike the vehicle, the drone has no LiDAR.
+GRIFFIN_DRONE_CAMERA_MAPPING: Dict[str, CameraID] = {
+    "front": CameraID.PCAM_F0,
+    "back": CameraID.PCAM_B0,
+    "left": CameraID.PCAM_L0,
+    "right": CameraID.PCAM_R0,
+    "bottom": CameraID.PCAM_D0,  # nadir / downward-looking
+}
+
+# Frame period for the drone side. Griffin renders all agents synchronously at
+# 10 Hz; the drone has no LiDAR to anchor timing, so frame ``N`` is placed on the
+# same 0.1 s grid as the vehicle side (mirrors ``GRIFFIN_LIDAR_PERIOD_US``).
+GRIFFIN_CAMERA_PERIOD_US: int = 100_000
+
+# Custom-modality id carrying aerial-specific state for the UAV ego.
+GRIFFIN_DRONE_AERIAL_MODALITY_ID: str = "aerial"
+
+# Static, log-scoped facts about the aerial agent. Per Griffin's design the UAV
+# carries 5 RGB cameras (4 cardinal + 1 nadir) and no LiDAR; each camera's
+# gimbal / mount orientation is encoded in its sensor-to-ego extrinsic, so it is
+# referenced here rather than duplicated as a separate field.
+GRIFFIN_DRONE_AERIAL_STATIC_METADATA: Dict[str, Any] = {
+    "platform": "uav_drone",
+    "agent_type": "uav",
+    "has_lidar": False,
+    "num_cameras": len(GRIFFIN_DRONE_CAMERA_MAPPING),
+    "nadir_camera": "bottom",
+    "gimbal_note": "per-camera gimbal/mount is encoded in each camera's sensor-to-ego extrinsic",
+}
+
+# Griffin's aerial agent is a simulated UAV. We model it as a single-agent ego
+# (Path 1): it reuses ``EgoStateSE3`` with representative sub-metre dimensions and
+# a meaningless ``wheel_base`` of 0. The ego frame coincides with the IMU frame
+# (identity extrinsics), matching the vehicle-side convention. Built lazily to
+# keep ``EgoStateSE3Metadata`` out of module import time.
+_GRIFFIN_DRONE_EGO_STATE_SE3_METADATA = None
+
+
+def build_griffin_drone_ego_metadata():
+    """Build the (cached) Griffin UAV ego metadata.
+
+    :return: The :class:`~py123d.datatypes.vehicle_state.ego_state_metadata.EgoStateSE3Metadata`
+        describing the Griffin aerial agent.
+    """
+    global _GRIFFIN_DRONE_EGO_STATE_SE3_METADATA  # noqa: PLW0603
+    if _GRIFFIN_DRONE_EGO_STATE_SE3_METADATA is None:
+        from py123d.datatypes.vehicle_state.ego_state_metadata import EgoStateSE3Metadata
+
+        _GRIFFIN_DRONE_EGO_STATE_SE3_METADATA = EgoStateSE3Metadata(
+            vehicle_name="griffin_carla_uav",
+            width=0.45,
+            length=0.45,
+            height=0.25,
+            wheel_base=0.0,
+            center_to_imu_se3=PoseSE3.identity(),
+            rear_axle_to_imu_se3=PoseSE3.identity(),
+        )
+    return _GRIFFIN_DRONE_EGO_STATE_SE3_METADATA

--- a/src/py123d/script/config/conversion/dataset/griffin_drone.yaml
+++ b/src/py123d/script/config/conversion/dataset/griffin_drone.yaml
@@ -1,0 +1,50 @@
+parser:
+  _target_: py123d.parser.griffin.griffin_drone_parser.GriffinDroneParser
+  _convert_: 'all'
+
+  # Available splits: griffin_{50scenes_25m,50scenes_40m,50scenes_55m,100scenes_random}_{train,val}
+  splits: ["griffin_50scenes_25m_train", "griffin_50scenes_25m_val"]
+  griffin_data_root: ${dataset_paths.griffin_data_root}
+
+  # Optional override for the official split files. When null, the train/val
+  # partitions embedded in py123d.parser.griffin.splits are used (shared with the
+  # vehicle side; Griffin assigns scenes by name, agent-agnostically).
+  split_data_root: null
+
+log_writer_config:
+  _target_: py123d.api.scene.arrow.utils.log_writer_config.LogWriterConfig
+  _convert_: 'all'
+
+  force_log_conversion: ${force_log_conversion}
+  force_map_conversion: ${force_map_conversion}
+
+  camera_store_option: "path" # "path", "jpeg_binary", "png_binary"
+  lidar_store_option: "path" #  "path", "binary" (unused: the drone has no LiDAR)
+  lidar_codec: null # None or "laz", "draco", "ipc_zstd", "ipc_lz4", "ipc"
+
+  infer_ego_dynamics: true
+  infer_box_dynamics: true
+
+log_writer:
+  _target_: py123d.api.scene.arrow.arrow_log_writer.ArrowLogWriter
+  _convert_: 'all'
+  log_writer_config: ${dataset.log_writer_config}
+  logs_root: ${dataset_paths.py123d_logs_root}
+  sensors_root: ${dataset_paths.py123d_sensors_root}
+  ipc_compression: null
+  ipc_compression_level: null
+
+  sync_config:
+    _target_: py123d.api.scene.arrow.arrow_log_writer.SyncConfig
+    _convert_: 'all'
+    # The drone is camera-only; sync on the front camera. All five drone cameras
+    # are rendered synchronously in CARLA, so any camera column is equivalent.
+    reference_column: camera.pcam_f0.timestamp_us
+    direction: "forward" # "forward" or "backward"
+
+map_writer:
+  _target_: py123d.api.map.arrow.arrow_map_writer.ArrowMapWriter
+  _convert_: 'all'
+  force_map_conversion: ${force_map_conversion}
+  maps_root: ${dataset_paths.py123d_maps_root}
+  logs_root: ${dataset_paths.py123d_logs_root}

--- a/tests/unit/datatypes/sensors/test_fisheye_mei_camera.py
+++ b/tests/unit/datatypes/sensors/test_fisheye_mei_camera.py
@@ -30,7 +30,7 @@ class TestFisheyeMEICameraType:
     def test_camera_id_members(self):
         """Test that fisheye members exist in the unified CameraID enum."""
         members = list(CameraID)
-        assert len(members) == 19
+        assert len(members) == 20  # +PCAM_D0 (Griffin drone nadir camera)
         assert CameraID.FMCAM_L in members
         assert CameraID.FMCAM_R in members
 


### PR DESCRIPTION
# Add Griffin drone-side (UAV) dataset parser

Builds on #147 (vehicle-side Griffin parser). Adds the aerial platform as a **separate single-agent** conversion target — `dataset=griffin_drone` - mirroring the vehicle-side structure and reusing its shared infrastructure unchanged.

## What this adds

| File | Change |
|---|---|
| `src/py123d/parser/griffin/griffin_drone_parser.py` | **new** — `GriffinDroneParser` / `GriffinDroneLogParser` |
| `src/py123d/script/config/conversion/dataset/griffin_drone.yaml` | **new** — Hydra conversion config |
| `src/py123d/parser/griffin/utils/griffin_constants.py` | +drone camera mapping, period, aerial metadata, UAV ego metadata |
| `src/py123d/datatypes/sensors/base_camera.py` | +`CameraID.PCAM_D0` (nadir camera) |
| `docs/datasets/griffin.rst` | +drone-side section |
| `tests/unit/datatypes/sensors/test_fisheye_mei_camera.py` | member count 19 → 20 (new `PCAM_D0`) |

## What it parses

UAV ego, five pinhole cameras (`front/back/left/right/bottom`, where `bottom` is the downward/nadir view), per-frame pose, and 3D boxes — all lifted to global coordinates, identical to the vehicle path. Aerial-specific state (altitude) is carried in a `CustomModality` (`modality_id="aerial"`), not new core datatypes, following the maintainer's prior steer on #147. No LiDAR and no maps on the drone side (`get_map_parsers()` returns `[]`); the sync reference column is switched to `camera.pcam_f0.timestamp_us` accordingly.

## Design decisions

- **Mirrors the vehicle parser** in class shape, box lifting, and metadata, so the two read as a matched pair.
- **`CustomModality` for aerial fields** rather than extending core multi-agent datatypes — keeps this a minimal, single-agent addition. A true cooperative (vehicle+drone) abstraction is intentionally out of scope here and belongs to the follow-up multi-agent RFC.
- **`PCAM_D0 = 19`** is the next free `CameraID` value (0–18 taken); added to `ALL_PINHOLE_CAMERA_IDS`. Verified collision-free.
- **Camera directory names confirmed against the official Griffin converter** (`tools/griffin_data_converter/visual_kitti.py`: drone sensors = `["bottom","front","back","left","right"]`), so `bottom` is the correct nadir dir.

## Integration safety

Changes to shared files are **strictly additive** — the vehicle parser, `griffin_utils.py`, and `registry.py` are **not modified** (the drone parser reuses them as-is). `griffin_constants.py` only appends drone constants (+ widens one typing import); `base_camera.py` only appends `PCAM_D0`. The vehicle conversion path is unaffected.

## Testing

- `pytest tests/unit` — **1868 passed** (incl. the updated `CameraID` count), Python 3.10.
- **Real-data conversion**: `dataset=griffin_drone` over `griffin_50scenes_25m` → **47/47 scenes** converted, writing complete 123D logs (ego, boxes, all five cameras incl. `camera.pcam_d0`, sync, and `custom.aerial`).
- **Visual**: rendered in `py123d-viser` — five camera frustums (including the nadir) at flight altitude, ego trajectory animated, boxes resting on the ground (confirms the ego→global lift).
- **Synthetic round-trip**: static world-frame boxes projected into ego frame and recovered after the parser's global lift to ~6e-7 m; altitude exact.
- `ruff check` / `ruff format` (pinned 0.14.6) and `pyright` - clean.

## Known limitation / open question

Vehicle and drone both emit `LogMetadata(dataset="griffin", log_name=<scene>)` for the *same* scene, so converting both into the **same** `PY123D_DATA_ROOT` collides on the log path. For now they should be converted to separate roots (or one side at a time). The agent identity is still distinguishable within a log via the aerial `CustomModality` (`agent_type="uav"`). Proper coexistence of both agents in a single store is a design question best resolved by the planned cooperative multi-agent abstraction rather than ad-hoc here - flagging for direction.