### PR TITLE
fix: allow uv sync support despite conflicting dependencies between datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ docs/build/
 _build/
 .doctrees/
 
+# uv
+*.lock
 
 # ruff
 .ruff_cache/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,14 @@ examples = [
     "torch",
 ]
 
+[tool.uv]
+conflicts = [
+    [
+        { extra = "waymo" },
+        { extra = "nuscenes" }
+    ]
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/py123d/visualization/matplotlib/timestamps.py
+++ b/src/py123d/visualization/matplotlib/timestamps.py
@@ -95,9 +95,9 @@ def plot_scene_timestamps(
     for mt in grouped:
         grouped[mt] = [k for k in grouped[mt] if k in key_timestamps]
         grouped[mt].sort(
-            key=lambda k: key_timestamps[k][key_timestamps[k] >= 0][0]
-            if np.any(key_timestamps[k] >= 0)
-            else float("inf")
+            key=lambda k: (
+                key_timestamps[k][key_timestamps[k] >= 0][0] if np.any(key_timestamps[k] >= 0) else float("inf")
+            )
         )
 
     # (label, modality_type_name, times, color)


### PR DESCRIPTION
Issue:
Currently running `uv sync` fails (no `uv.lock` file is built) due to conflicting dependencies inside `pyproject.toml` between `waymo` and `nuscenes`.

Solution:
Stating these conflicts inside `tool.uv`. Now `uv sync` will not fail and produces a `uv.lock` file. In addition, running `uv sync --extra waymo` or `uv sync --extra nuscenes` allows the smooth switch between projects.

Additional minor changes:
- Formatting change resulting from running `ruff check --fix .` and `ruff format .`
- Adding `*.lock` to `.gitignore`.