### PR TITLE
Add Griffin map support via bundled CARLA town maps

### DIFF
--- a/docs/datasets/griffin.rst
+++ b/docs/datasets/griffin.rst
@@ -58,8 +58,12 @@ Available Modalities
      - Ego poses are provided in an ENU world frame; vehicle parameters follow the CARLA
        ego model, see :class:`~py123d.datatypes.vehicle_state.EgoStateSE3`.
    * - Map
-     - X
-     - n/a
+     - ✓
+     - Griffin scenes are rendered on four stock CARLA towns (``Town03``, ``Town06``,
+       ``Town07``, ``Town10HD``). The bundled OpenDRIVE town maps are converted as global
+       maps under the ``griffin`` dataset; each log links to its town via ``location``.
+       Griffin's global (ENU) frame coincides with the CARLA map frame, so no additional
+       transform is required.
    * - Bounding Boxes
      - ✓
      - Bounding boxes are available with the :class:`~py123d.parser.registry.GriffinBoxDetectionLabel`.

--- a/src/py123d/parser/griffin/griffin_drone_parser.py
+++ b/src/py123d/parser/griffin/griffin_drone_parser.py
@@ -57,6 +57,7 @@ from py123d.parser.base_dataset_parser import (
     ModalitiesSync,
     ParsedCamera,
 )
+from py123d.parser.griffin.griffin_map_parser import get_griffin_map_parsers, griffin_map_metadata
 from py123d.parser.griffin.utils.griffin_constants import (
     GRIFFIN_BOX_DETECTION_FROM_STR,
     GRIFFIN_BOX_DETECTIONS_SE3_METADATA,
@@ -78,6 +79,7 @@ from py123d.parser.griffin.utils.griffin_utils import (
     parse_label_file,
     pose_dict_to_ego_to_global_se3,
     read_json,
+    town_from_scene_name,
 )
 
 logger = logging.getLogger(__name__)
@@ -95,7 +97,7 @@ def _default_split_file(subset: str) -> Path:
     :param subset: Subset name, e.g. ``"griffin_50scenes_25m"``.
     :return: Path to the packaged ``splits/{subset}.json``.
     """
-    return Path(str(resources.files("py123d.parser.griffin").joinpath("splits", f"{subset}.json")))
+    return Path(str(resources.files("py123d.parser.griffin").joinpath("splits").joinpath(f"{subset}.json")))
 
 
 class GriffinDroneParser(BaseDatasetParser):
@@ -175,8 +177,8 @@ class GriffinDroneParser(BaseDatasetParser):
         return log_parsers
 
     def get_map_parsers(self) -> List[BaseMapParser]:
-        """Inherited, see superclass. Griffin provides no HD map."""
-        return []
+        """Inherited, see superclass. One global map per Griffin CARLA town."""
+        return get_griffin_map_parsers()
 
 
 class GriffinDroneLogParser(BaseLogParser):
@@ -213,11 +215,17 @@ class GriffinDroneLogParser(BaseLogParser):
 
     def get_log_metadata(self) -> LogMetadata:
         """Inherited, see superclass."""
+        _town = town_from_scene_name(self._scene_name)
         return LogMetadata(
             dataset="griffin",
             split=self._split,
             log_name=self._scene_name,
-            location=self._subset,
+            # The CARLA town doubles as location, linking the log to its global
+            # map at {maps_root}/griffin/griffin_{town}.arrow (nuScenes pattern).
+            location=_town,
+            # Attach the global map metadata so ``has_map`` / ``map_locations``
+            # scene filters resolve for Griffin (map itself loads by location).
+            map_metadata=griffin_map_metadata(_town),
         )
 
     def _build_camera_metadata(self) -> Dict[CameraID, PinholeCameraMetadata]:

--- a/src/py123d/parser/griffin/griffin_map_parser.py
+++ b/src/py123d/parser/griffin/griffin_map_parser.py
@@ -1,0 +1,76 @@
+"""Map parser for the Griffin dataset.
+
+Griffin is rendered in CARLA on four stock towns (Town03, Town06, Town07,
+Town10HD) whose OpenDRIVE definitions are already bundled with py123d for the
+:class:`~py123d.parser.opendrive.opendrive_parser.OpenDriveParser`. Griffin's
+global (ENU) frame coincides with the CARLA/OpenDRIVE map frame (identity
+transform), so map support reduces to re-exporting the bundled town maps under
+the ``griffin`` dataset with the town as ``location`` — mirroring the global-map
+linkage used by nuScenes (``map_is_per_log=False``; logs resolve their map via
+``{maps_root}/griffin/griffin_{town}.arrow``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final, List, Tuple
+
+from typing_extensions import override
+
+from py123d.datatypes.metadata.map_metadata import MapMetadata
+from py123d.parser.base_dataset_parser import BaseMapParser
+from py123d.parser.opendrive.opendrive_map_parser import OpenDriveMapParser
+
+_CARLA_MAPS_DIR: Final[Path] = Path(__file__).parents[1] / "opendrive" / "carla_maps"
+
+GRIFFIN_TOWNS: Final[Tuple[str, ...]] = ("Town03", "Town06", "Town07", "Town10HD")
+"""CARLA towns used by the official Griffin release."""
+
+
+class GriffinMapParser(OpenDriveMapParser):
+    """Map parser for one Griffin (CARLA) town.
+
+    Thin subclass of :class:`~py123d.parser.opendrive.opendrive_map_parser.OpenDriveMapParser`
+    over the bundled CARLA ``.xodr.gz`` files; only the map metadata is
+    re-branded so the maps are written under the ``griffin`` dataset and picked
+    up by Griffin logs via their ``location``.
+    """
+
+    def __init__(self, town: str) -> None:
+        """Initialize the :class:`GriffinMapParser`.
+
+        :param town: CARLA town name, e.g. ``"Town03"``. Must be one of
+            :data:`GRIFFIN_TOWNS`.
+        """
+        assert town in GRIFFIN_TOWNS, f"Town {town} is not part of Griffin. Available towns: {GRIFFIN_TOWNS}"
+        self._town = town
+        super().__init__(xodr_path=_CARLA_MAPS_DIR / f"{town}.xodr.gz", location=town)
+
+    @override
+    def get_map_metadata(self) -> MapMetadata:
+        """Inherited, see superclass."""
+        return griffin_map_metadata(self._town)
+
+
+def griffin_map_metadata(town: str) -> MapMetadata:
+    """Build the global :class:`MapMetadata` for a Griffin ``town``.
+
+    Single source of truth shared by :class:`GriffinMapParser` and the log
+    parsers (which attach it to ``LogMetadata`` so ``has_map`` / ``map_locations``
+    scene filters resolve correctly).
+
+    :param town: CARLA town name, e.g. ``"Town03"``.
+    :return: Global map metadata (``dataset="griffin"``, ``map_is_per_log=False``).
+    """
+    return MapMetadata(dataset="griffin", location=town, map_has_z=True, map_is_per_log=False)
+
+
+def get_griffin_map_parsers() -> List[BaseMapParser]:
+    """Return one :class:`GriffinMapParser` per Griffin town.
+
+    Shared by the vehicle- and drone-side dataset parsers; the map writer skips
+    towns that were already converted, so running both conversions is safe.
+
+    :return: List of map parsers covering :data:`GRIFFIN_TOWNS`.
+    """
+    return [GriffinMapParser(town) for town in GRIFFIN_TOWNS]

--- a/src/py123d/parser/griffin/griffin_parser.py
+++ b/src/py123d/parser/griffin/griffin_parser.py
@@ -51,6 +51,7 @@ from py123d.parser.base_dataset_parser import (
     ParsedCamera,
     ParsedLidar,
 )
+from py123d.parser.griffin.griffin_map_parser import get_griffin_map_parsers, griffin_map_metadata
 from py123d.parser.griffin.utils.griffin_constants import (
     GRIFFIN_BOX_DETECTION_FROM_STR,
     GRIFFIN_BOX_DETECTIONS_SE3_METADATA,
@@ -72,6 +73,7 @@ from py123d.parser.griffin.utils.griffin_utils import (
     pose_dict_to_ego_to_global_se3,
     read_json,
     sensor_to_ego_pose_se3,
+    town_from_scene_name,
 )
 
 logger = logging.getLogger(__name__)
@@ -86,7 +88,7 @@ def _default_split_file(subset: str) -> Path:
     :param subset: Subset name, e.g. ``"griffin_50scenes_25m"``.
     :return: Path to the packaged ``splits/{subset}.json``.
     """
-    return Path(str(resources.files("py123d.parser.griffin").joinpath("splits", f"{subset}.json")))
+    return Path(str(resources.files("py123d.parser.griffin").joinpath("splits").joinpath(f"{subset}.json")))
 
 
 class GriffinParser(BaseDatasetParser):
@@ -166,8 +168,8 @@ class GriffinParser(BaseDatasetParser):
         return log_parsers
 
     def get_map_parsers(self) -> List[BaseMapParser]:
-        """Inherited, see superclass. Griffin provides no HD map."""
-        return []
+        """Inherited, see superclass. One global map per Griffin CARLA town."""
+        return get_griffin_map_parsers()
 
 
 class GriffinLogParser(BaseLogParser):
@@ -204,11 +206,17 @@ class GriffinLogParser(BaseLogParser):
 
     def get_log_metadata(self) -> LogMetadata:
         """Inherited, see superclass."""
+        _town = town_from_scene_name(self._scene_name)
         return LogMetadata(
             dataset="griffin",
             split=self._split,
             log_name=self._scene_name,
-            location=self._subset,
+            # The CARLA town doubles as location, linking the log to its global
+            # map at {maps_root}/griffin/griffin_{town}.arrow (nuScenes pattern).
+            location=_town,
+            # Attach the global map metadata so ``has_map`` / ``map_locations``
+            # scene filters resolve for Griffin (map itself loads by location).
+            map_metadata=griffin_map_metadata(_town),
         )
 
     def _build_camera_metadata(self) -> Dict[CameraID, PinholeCameraMetadata]:

--- a/src/py123d/parser/griffin/utils/griffin_utils.py
+++ b/src/py123d/parser/griffin/utils/griffin_utils.py
@@ -136,6 +136,23 @@ def load_scene_index(vehicle_root: Union[str, Path]) -> List[Tuple[str, List[str
     return scenes
 
 
+def town_from_scene_name(scene_name: str) -> str:
+    """Extract the CARLA town from a full Griffin scene name.
+
+    Scene names embed the town as ``scene-{idx:04d}-{Town}-{seq}``
+    (e.g. ``scene-0026-Town07-001`` -> ``Town07``). The town doubles as the
+    log's ``location``, linking it to the matching global Griffin map.
+
+    :param scene_name: Full scene identifier, e.g. ``scene-0026-Town07-001``.
+    :return: The CARLA town name, e.g. ``Town07``.
+    :raises ValueError: If no town component is found in ``scene_name``.
+    """
+    for part in scene_name.split("-"):
+        if part.startswith("Town"):
+            return part
+    raise ValueError(f"Could not extract CARLA town from Griffin scene name: {scene_name}")
+
+
 def load_split_scene_names(split_file: Union[str, Path], kind: str) -> List[str]:
     """Read the official split file and return the scene names for one partition.
 


### PR DESCRIPTION
## What

Wires HD-map support into the Griffin vehicle-side and drone-side parsers. Griffin is rendered in CARLA on four stock towns (Town03, Town06, Town07, Town10HD) whose OpenDRIVE definitions are already bundled with py123d, so this is a wiring change rather than a new converter.

## How

- **`griffin_map_parser.py` (new):** `GriffinMapParser`, a thin subclass of `OpenDriveMapParser` over the bundled `carla_maps/*.xodr.gz` files, re-branded to `dataset="griffin"` with the town as `location` (`map_has_z=True`, `map_is_per_log=False`). `get_griffin_map_parsers()` returns one parser per town, shared by both dataset parsers (the map writer skips already-converted towns, so running vehicle and drone conversions in either order is safe). A `griffin_map_metadata(town)` helper is the single source of truth for the metadata.
- **Log→map linkage (nuScenes pattern):** `LogMetadata.location` now carries the CARLA town, extracted from the scene name via `town_from_scene_name` (`scene-0026-Town07-001` → `Town07`), so each log resolves its map at `{maps_root}/griffin/griffin_{town}.arrow`. `map_metadata` is attached per-log so `has_map` / `map_locations` scene filters resolve for Griffin.
- **No transform needed:** Griffin's global (ENU) frame coincides with the CARLA/OpenDRIVE map frame (identity), verified empirically (median box-to-road-surface distance ~0.24 m on Town03).
- **Docs:** Map row in `docs/datasets/griffin.rst` updated.
- **Drive-by:** chained `Traversable.joinpath` in `_default_split_file` (both parsers) so pyright is clean under Python 3.9/3.10, where `joinpath` is single-arg.

## Verification

- `pre-commit run --all-files`: all hooks pass
- `pytest tests/unit`: 1918 passed
- `pytest tests/docs`: passed (docs touched)
- pyright: 0 errors under 3.10
- Visual: verified map/box alignment on converted Griffin data in viser and via a top-down BEV overlay.