### PR TITLE
Lazy scene index

### DIFF
--- a/src/py123d/api/scene/arrow/arrow_scene_builder.py
+++ b/src/py123d/api/scene/arrow/arrow_scene_builder.py
@@ -1,13 +1,20 @@
 import logging
 import os
 import random
+from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 import pyarrow as pa
 
 from py123d.api.scene.arrow.arrow_scene_api import ArrowSceneAPI
+from py123d.api.scene.arrow.lazy_scene_sequence import (
+    LazySceneSequence,
+    LogSceneIndex,
+    apply_lazy_post_filters,
+    build_log_scene_index,
+)
 from py123d.api.scene.arrow.utils.scene_builder_utils import (
     check_log_passes_metadata_filters,
     filter_scene_metadata_candidates,
@@ -31,6 +38,9 @@ from py123d.datatypes.metadata import SceneMetadata
 from py123d.datatypes.metadata.log_metadata import LogMetadata
 
 logger = logging.getLogger(__name__)
+
+_DISCOVERY_THREADS = 8
+"""Threads scanning directories during log discovery; the work is filesystem lookups, not Python."""
 
 
 class ArrowSceneBuilder(SceneBuilder):
@@ -56,7 +66,7 @@ class ArrowSceneBuilder(SceneBuilder):
         self._logs_root = Path(logs_root)
         self._maps_root = Path(maps_root)
 
-    def get_scenes(self, filter: SceneFilter, executor: Executor) -> List[SceneAPI]:
+    def get_scenes(self, filter: SceneFilter, executor: Executor, lazy: bool = False) -> Sequence[SceneAPI]:
         """Inherited, see superclass."""
 
         # Category 1: Log discovery (filesystem-only)
@@ -67,6 +77,9 @@ class ArrowSceneBuilder(SceneBuilder):
         # Categories 2 & 3: Metadata filtering + scene generation (parallelized across logs)
         # Pre-convert scene UUIDs to binary once (shared across all executor workers)
         target_uuids_binary = scene_uuids_to_binary(filter.scene_uuids) if filter.scene_uuids is not None else None
+        if lazy:
+            return self._get_scenes_lazily(log_paths, filter, executor, target_uuids_binary)
+
         scenes: List[SceneAPI] = executor_map_chunked_list(
             executor,
             partial(
@@ -83,6 +96,29 @@ class ArrowSceneBuilder(SceneBuilder):
         scenes = _apply_post_filters(scenes, filter)
         return scenes
 
+    def _get_scenes_lazily(
+        self,
+        log_paths: List[Path],
+        filter: SceneFilter,
+        executor: Executor,
+        target_uuids_binary: Optional[pa.Array],
+    ) -> Sequence[SceneAPI]:
+        """Enumerate scenes as per-log columns, building none of them.
+
+        :param log_paths: The discovered log directories.
+        :param filter: The scene filter.
+        :param executor: Executor the per-log indexing runs on.
+        :param target_uuids_binary: Pre-converted binary(16) Arrow array of target UUIDs, or None.
+        :return: The scenes, materialized only when indexed.
+        """
+        log_indices = executor_map_chunked_list(
+            executor,
+            partial(_index_log_dirs, filter=filter, target_uuids_binary=target_uuids_binary),
+            log_paths,
+            name="Scene indexing",
+        )
+        return apply_lazy_post_filters(LazySceneSequence(log_indices), filter)
+
 
 # --- Category 1: Log discovery ---
 
@@ -98,20 +134,48 @@ def _parse_valid_log_dirs(logs_root: Path, filter: SceneFilter) -> List[Path]:
     :return: Sorted list of valid log directory paths.
     """
     split_names = filter.split_names if filter.split_names is not None else _discover_split_names(logs_root, filter)
-    log_paths: List[Path] = []
-    for split_name in split_names:
-        split_dir = logs_root / split_name
-        if not split_dir.exists():
-            continue
-        for dirpath, dirnames, filenames in os.walk(split_dir, topdown=True):
-            if "sync.arrow" not in filenames:
-                continue
-            log_path = Path(dirpath)
-            if filter.log_names is None or log_path.name in filter.log_names:
-                log_paths.append(log_path)
-            # A log has no nested logs.
-            dirnames[:] = []
+    log_names = set(filter.log_names) if filter.log_names is not None else None
+    roots = [logs_root / split_name for split_name in split_names if (logs_root / split_name).is_dir()]
+
+    log_paths: List[Path] = [root for root in roots if (root / "sync.arrow").exists()]
+    frontier = [root for root in roots if root not in log_paths]
+    with ThreadPoolExecutor(max_workers=_DISCOVERY_THREADS) as executor:
+        while frontier:
+            next_frontier: List[Path] = []
+            for found, subdirectories in executor.map(_scan_for_logs, frontier):
+                log_paths.extend(found)
+                next_frontier.extend(subdirectories)
+            frontier = next_frontier
+
+    if log_names is not None:
+        log_paths = [path for path in log_paths if path.name in log_names]
     return sorted(log_paths)
+
+
+def _scan_for_logs(directory: Path) -> Tuple[List[Path], List[Path]]:
+    """Split a directory's subdirectories into logs and directories still to search.
+
+    Probing for ``sync.arrow`` directly costs one lookup, where listing a log
+    directory would read every modality file it holds.
+
+    :param directory: The directory to scan.
+    :return: Tuple of (log directories found, subdirectories to descend into).
+    """
+    logs: List[Path] = []
+    subdirectories: List[Path] = []
+    try:
+        entries = list(os.scandir(directory))
+    except OSError:
+        return logs, subdirectories
+    for entry in entries:
+        if not entry.is_dir(follow_symlinks=False):
+            continue
+        # A log has no nested logs, so a match ends the descent.
+        if os.path.exists(os.path.join(entry.path, "sync.arrow")):
+            logs.append(Path(entry.path))
+        else:
+            subdirectories.append(Path(entry.path))
+    return logs, subdirectories
 
 
 def _discover_split_names(logs_root: Path, filter: SceneFilter) -> List[str]:
@@ -129,6 +193,22 @@ def _discover_split_names(logs_root: Path, filter: SceneFilter) -> List[str]:
 
 
 # --- Categories 2 & 3: Per-log scene extraction ---
+
+
+def _index_log_dirs(
+    log_dirs: List[Path],
+    filter: SceneFilter,
+    target_uuids_binary: Optional[pa.Array] = None,
+) -> List[LogSceneIndex]:
+    """Index multiple log directories (chunked batch wrapper).
+
+    :param log_dirs: List of log directory paths to index.
+    :param filter: The scene filter.
+    :param target_uuids_binary: Pre-converted binary(16) Arrow array of target UUIDs, or None.
+    :return: One index per log that contributes at least one scene.
+    """
+    indices = [build_log_scene_index(log_dir, filter, target_uuids_binary) for log_dir in log_dirs]
+    return [index for index in indices if index is not None]
 
 
 def _extract_scenes_from_log_dirs(

--- a/src/py123d/api/scene/arrow/arrow_scene_builder.py
+++ b/src/py123d/api/scene/arrow/arrow_scene_builder.py
@@ -66,7 +66,7 @@ class ArrowSceneBuilder(SceneBuilder):
         self._logs_root = Path(logs_root)
         self._maps_root = Path(maps_root)
 
-    def get_scenes(self, filter: SceneFilter, executor: Executor, lazy: bool = False) -> Sequence[SceneAPI]:
+    def get_scenes(self, filter: SceneFilter, executor: Executor) -> Sequence[SceneAPI]:
         """Inherited, see superclass."""
 
         # Category 1: Log discovery (filesystem-only)
@@ -77,9 +77,6 @@ class ArrowSceneBuilder(SceneBuilder):
         # Categories 2 & 3: Metadata filtering + scene generation (parallelized across logs)
         # Pre-convert scene UUIDs to binary once (shared across all executor workers)
         target_uuids_binary = scene_uuids_to_binary(filter.scene_uuids) if filter.scene_uuids is not None else None
-        if lazy:
-            return self._get_scenes_lazily(log_paths, filter, executor, target_uuids_binary)
-
         scenes: List[SceneAPI] = executor_map_chunked_list(
             executor,
             partial(
@@ -96,27 +93,35 @@ class ArrowSceneBuilder(SceneBuilder):
         scenes = _apply_post_filters(scenes, filter)
         return scenes
 
-    def _get_scenes_lazily(
-        self,
-        log_paths: List[Path],
-        filter: SceneFilter,
-        executor: Executor,
-        target_uuids_binary: Optional[pa.Array],
-    ) -> Sequence[SceneAPI]:
-        """Enumerate scenes as per-log columns, building none of them.
 
-        :param log_paths: The discovered log directories.
-        :param filter: The scene filter.
-        :param executor: Executor the per-log indexing runs on.
-        :param target_uuids_binary: Pre-converted binary(16) Arrow array of target UUIDs, or None.
-        :return: The scenes, materialized only when indexed.
-        """
+class LazyArrowSceneBuilder(ArrowSceneBuilder):
+    """Builds scenes from Arrow log directories, one scene at a time on access.
+
+    Enumeration keeps a split as a few numpy arrays per log and constructs a
+    :class:`~py123d.api.scene.scene_api.SceneAPI` when the returned sequence is
+    indexed, rather than one per candidate frame up front. Suited to splits
+    whose scene count makes an object per scene expensive; the returned
+    sequence is otherwise interchangeable with the eager builder's list.
+    """
+
+    def get_scenes(self, filter: SceneFilter, executor: Executor) -> Sequence[SceneAPI]:
+        """Inherited, see superclass."""
+
+        # Category 1: Log discovery (filesystem-only)
+        log_paths = _parse_valid_log_dirs(self._logs_root, filter)
+        if len(log_paths) == 0:
+            return []
+
+        # Categories 2 & 3, as per-log columns rather than scene objects
+        target_uuids_binary = scene_uuids_to_binary(filter.scene_uuids) if filter.scene_uuids is not None else None
         log_indices = executor_map_chunked_list(
             executor,
             partial(_index_log_dirs, filter=filter, target_uuids_binary=target_uuids_binary),
             log_paths,
             name="Scene indexing",
         )
+
+        # Category 4: Post-filtering
         return apply_lazy_post_filters(LazySceneSequence(log_indices), filter)
 
 

--- a/src/py123d/api/scene/arrow/lazy_scene_sequence.py
+++ b/src/py123d/api/scene/arrow/lazy_scene_sequence.py
@@ -1,0 +1,425 @@
+"""Scene enumeration that stays columnar until a scene is actually asked for.
+
+The eager builder materializes one :class:`SceneMetadata` and one
+:class:`ArrowSceneAPI` per candidate frame before any of them is used, which
+costs a Python object per tick of the dataset. This module keeps the same
+information as a few numpy arrays per log and builds a scene on ``__getitem__``.
+"""
+
+import logging
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import FrozenSet, List, Optional, Sequence, Set, Tuple, Union, overload
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.compute as pc
+
+from py123d.api.scene.arrow.arrow_scene_api import ArrowSceneAPI
+from py123d.api.scene.arrow.utils.scene_builder_utils import (
+    _resolve_requirement,
+    check_log_passes_metadata_filters,
+    infer_iteration_duration_s,
+    resolve_iteration_counts,
+    resolve_iteration_stride,
+    resolve_scene_step_size,
+    resolve_scene_uuid_indices,
+)
+from py123d.api.scene.scene_api import SceneAPI
+from py123d.api.scene.scene_filter import SceneFilter
+from py123d.api.utils.arrow_helper import get_lru_cached_arrow_table
+from py123d.api.utils.arrow_metadata_utils import get_metadata_from_arrow_schema
+from py123d.common.utils.uuid_utils import convert_to_str_uuid
+from py123d.datatypes.metadata import SceneMetadata
+from py123d.datatypes.metadata.log_metadata import LogMetadata
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class LogSceneIndex:
+    """The scenes of one log, as columns instead of objects.
+
+    Every scene of a log shares its stride and iteration counts, so only the
+    anchor frames differ between them.
+    """
+
+    log_dir: Path
+    """Directory the scenes are read from."""
+
+    dataset: str
+    """Dataset the log belongs to."""
+
+    split: str
+    """Split the log belongs to."""
+
+    anchor_indices: np.ndarray
+    """Sync-table row of each scene's initial frame, ascending, int64."""
+
+    anchor_timestamps_us: np.ndarray
+    """Simulation timestamp of each scene's initial frame in microseconds, int64."""
+
+    num_rows: int
+    """Rows in the log's sync table."""
+
+    stride: int
+    """Raw sync frames per logical iteration."""
+
+    history_iterations: int
+    """History iterations every scene of this log carries."""
+
+    future_iterations: Optional[int]
+    """Future iterations every scene carries, or None when scenes run to the log's end."""
+
+    effective_duration_s: float
+    """Duration of one logical iteration in seconds, stride included."""
+
+    def num_future_at(self, anchor_index: int) -> int:
+        """Future iterations of the scene anchored at a frame.
+
+        Args:
+            anchor_index: Sync-table row of the scene's initial frame.
+
+        Returns:
+            The scene's future iteration count.
+        """
+        if self.future_iterations is not None:
+            return self.future_iterations
+        return max((self.num_rows - anchor_index - 1) // self.stride, 0)
+
+    def scene_metadata_at(self, anchor_index: int) -> SceneMetadata:
+        """Build the metadata of the scene anchored at a frame.
+
+        Args:
+            anchor_index: Sync-table row of the scene's initial frame.
+
+        Returns:
+            The scene metadata, matching what the eager builder produces.
+        """
+        sync_table = get_lru_cached_arrow_table(str(self.log_dir / "sync.arrow"))
+        num_future = self.num_future_at(anchor_index)
+        return SceneMetadata(
+            dataset=self.dataset,
+            split=self.split,
+            initial_uuid=convert_to_str_uuid(sync_table["sync.uuid"][anchor_index].as_py()),
+            initial_idx=anchor_index,
+            num_future_iterations=num_future,
+            num_history_iterations=self.history_iterations,
+            future_duration_s=num_future * self.effective_duration_s,
+            history_duration_s=self.history_iterations * self.effective_duration_s,
+            iteration_duration_s=self.effective_duration_s,
+            target_iteration_stride=self.stride,
+        )
+
+
+class LazySceneSequence(Sequence[SceneAPI]):
+    """A scene list that builds each :class:`SceneAPI` when it is indexed.
+
+    Indexing is the only operation that touches a log, so holding the sequence
+    costs a few arrays per log rather than an object per scene.
+    """
+
+    def __init__(self, log_indices: List[LogSceneIndex]) -> None:
+        """Initialize the sequence over per-log indices.
+
+        :param log_indices: The indexed logs, in the order their scenes appear.
+        """
+        self._log_indices = [index for index in log_indices if len(index.anchor_indices) > 0]
+        counts = [len(index.anchor_indices) for index in self._log_indices]
+        # One extra leading zero, so a scene's log is a searchsorted away.
+        self._log_starts = np.concatenate([[0], np.cumsum(counts)]).astype(np.int64)
+        self._order: Optional[np.ndarray] = None
+
+    def __len__(self) -> int:
+        """Inherited, see superclass."""
+        if self._order is not None:
+            return len(self._order)
+        return int(self._log_starts[-1])
+
+    @overload
+    def __getitem__(self, index: int) -> SceneAPI: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> List[SceneAPI]: ...
+
+    def __getitem__(self, index: Union[int, slice]) -> Union[SceneAPI, List[SceneAPI]]:
+        """Inherited, see superclass."""
+        if isinstance(index, slice):
+            return [self._build(position) for position in range(*index.indices(len(self)))]
+        if index < 0:
+            index += len(self)
+        if not 0 <= index < len(self):
+            raise IndexError(f"scene index {index} out of range for {len(self)} scenes")
+        return self._build(index)
+
+    def _build(self, position: int) -> SceneAPI:
+        """Materialize the scene at a position in the sequence.
+
+        :param position: Position in this sequence.
+        :return: The scene.
+        """
+        flat_index = int(self._order[position]) if self._order is not None else position
+        log_position = int(np.searchsorted(self._log_starts, flat_index, side="right")) - 1
+        log_index = self._log_indices[log_position]
+        anchor_index = int(log_index.anchor_indices[flat_index - self._log_starts[log_position]])
+        return ArrowSceneAPI(log_dir=log_index.log_dir, scene_metadata=log_index.scene_metadata_at(anchor_index))
+
+    def anchor_columns(self) -> Tuple[List[str], np.ndarray, np.ndarray]:
+        """Identify every scene by its log and initial timestamp, building none of them.
+
+        Pairing two sensor views of the same drive needs exactly this, and the
+        index already holds it, so no scene has to be read back. Columns rather
+        than pairs, so a whole split can be matched without Python-level work.
+
+        :return: Tuple of (log names, index into those names per scene, initial timestamp
+            in microseconds per scene), the last two in sequence order.
+        """
+        log_names = [log_index.log_dir.name for log_index in self._log_indices]
+        if not self._log_indices:
+            return log_names, np.empty(0, dtype=np.int64), np.empty(0, dtype=np.int64)
+
+        counts = [len(log_index.anchor_indices) for log_index in self._log_indices]
+        name_indices = np.repeat(np.arange(len(log_names), dtype=np.int64), counts)
+        timestamps = np.concatenate([log_index.anchor_timestamps_us for log_index in self._log_indices])
+        if self._order is not None:
+            name_indices, timestamps = name_indices[self._order], timestamps[self._order]
+        return log_names, name_indices, timestamps
+
+    def anchor_keys(self) -> List[Tuple[str, int]]:
+        """Identify every scene by its log and initial timestamp, as pairs.
+
+        :return: One (log name, initial timestamp in microseconds) pair per scene, in sequence order.
+        """
+        log_names, name_indices, timestamps = self.anchor_columns()
+        return [(log_names[int(name_index)], int(timestamp)) for name_index, timestamp in zip(name_indices, timestamps)]
+
+    def reorder(self, order: np.ndarray) -> None:
+        """Restrict and reorder the sequence without materializing anything.
+
+        :param order: Positions into the current flat order, in their new order.
+        """
+        self._order = order if self._order is None else self._order[order]
+
+
+def _scope_offsets(scope: FrozenSet[str], history_iterations: int, future_iterations: int, stride: int) -> np.ndarray:
+    """Frame offsets from a scene's anchor that a modality scope covers.
+
+    :param scope: Temporal segments from :data:`~py123d.api.scene.scene_filter.VALID_MODALITY_SCOPES`.
+    :param history_iterations: History iterations of the scene.
+    :param future_iterations: Future iterations of the scene.
+    :param stride: Raw sync frames per logical iteration.
+    :return: Sorted offsets, int64.
+    """
+    offsets: Set[int] = set()
+    if "history" in scope:
+        offsets.update(range(-history_iterations * stride, 0, stride))
+    if "initial" in scope:
+        offsets.add(0)
+    if "future" in scope:
+        offsets.update(range(stride, future_iterations * stride + 1, stride))
+    return np.array(sorted(offsets), dtype=np.int64)
+
+
+def _null_mask(sync_table: pa.Table, column_name: str, cache: dict) -> np.ndarray:
+    """Per-row null mask of a sync column, computed once per log.
+
+    :param sync_table: The sync Arrow table.
+    :param column_name: Column to mask.
+    :param cache: Per-log store of already-computed masks.
+    :return: Boolean array, True where the column is null.
+    """
+    if column_name not in cache:
+        cache[column_name] = np.asarray(pc.is_null(sync_table.column(column_name)))
+    return cache[column_name]
+
+
+def _keep_anchors(
+    sync_table: pa.Table,
+    anchors: np.ndarray,
+    filter: SceneFilter,
+    history_iterations: int,
+    future_iterations: int,
+    stride: int,
+) -> np.ndarray:
+    """Select the anchors whose scenes satisfy every modality requirement.
+
+    Checks all anchors of a log at once: the scoped frames of a scene are its
+    anchor plus a fixed set of offsets, so completeness is one lookup into the
+    column's null mask.
+
+    :param sync_table: The sync Arrow table.
+    :param anchors: Candidate anchor rows, int64.
+    :param filter: The scene filter.
+    :param history_iterations: History iterations every candidate carries.
+    :param future_iterations: Future iterations every candidate carries.
+    :param stride: Raw sync frames per logical iteration.
+    :return: Boolean array over ``anchors``, True for the scenes to keep.
+    """
+    keep = np.ones(len(anchors), dtype=bool)
+    if filter.required_scene_modalities is None or len(anchors) == 0:
+        return keep
+
+    sync_column_set = set(sync_table.column_names)
+    mask_cache: dict = {}
+    for requirement in filter.required_scene_modalities:
+        columns, quantifier, scope = _resolve_requirement(requirement, sync_column_set)
+        if len(columns) == 0:
+            # An "all" requirement over no columns is vacuously satisfied; an
+            # "any" requirement over no columns keeps nothing.
+            if quantifier != "all":
+                keep[:] = False
+                break
+            continue
+
+        offsets = _scope_offsets(scope, history_iterations, future_iterations, stride)
+        frames = anchors[:, None] + offsets[None, :]
+        complete: Optional[np.ndarray] = None
+        for column_name in columns:
+            column_complete = ~_null_mask(sync_table, column_name, mask_cache)[frames].any(axis=1)
+            if complete is None:
+                complete = column_complete
+            elif quantifier == "all":
+                complete &= column_complete
+            else:
+                complete |= column_complete
+        assert complete is not None
+        keep &= complete
+        if not keep.any():
+            break
+    return keep
+
+
+def build_log_scene_index(
+    log_dir: Path,
+    filter: SceneFilter,
+    target_uuids_binary: Optional[pa.Array] = None,
+) -> Optional[LogSceneIndex]:
+    """Index one log's scenes without building a scene object.
+
+    :param log_dir: The log directory.
+    :param filter: The scene filter.
+    :param target_uuids_binary: Pre-converted binary(16) Arrow array of target UUIDs, or None.
+    :return: The log's index, or None when the log contributes no scene.
+    """
+    try:
+        sync_table = get_lru_cached_arrow_table(str(log_dir / "sync.arrow"))
+        log_metadata = get_metadata_from_arrow_schema(sync_table.schema, LogMetadata)
+        if not check_log_passes_metadata_filters(log_metadata, sync_table.column_names, filter):
+            return None
+
+        raw_duration_s = infer_iteration_duration_s(sync_table)
+        stride = resolve_iteration_stride(filter, raw_duration_s)
+        if stride is None:
+            return None
+        future_iterations, history_iterations = resolve_iteration_counts(filter, raw_duration_s, stride)
+        step_idx = max(1, resolve_scene_step_size(filter, raw_duration_s, stride))
+
+        uuid_indices: Optional[Set[int]] = None
+        if target_uuids_binary is not None:
+            uuid_indices = resolve_scene_uuid_indices(sync_table, target_uuids_binary)
+            if uuid_indices is None:
+                return None
+
+        num_rows = sync_table.num_rows
+        initial_idx = history_iterations * stride
+        if future_iterations is None:
+            # Scenes reach to the end of the log, so their future length differs
+            # per anchor and the scoped frames cannot share one offset array.
+            candidates = (
+                np.array(sorted(index for index in uuid_indices if index >= initial_idx), dtype=np.int64)
+                if uuid_indices is not None
+                else np.array([initial_idx], dtype=np.int64)
+            )
+            keep = np.array(
+                [
+                    _keep_anchors(
+                        sync_table,
+                        np.array([anchor], dtype=np.int64),
+                        filter,
+                        history_iterations,
+                        max((num_rows - int(anchor) - 1) // stride, 0),
+                        stride,
+                    )[0]
+                    for anchor in candidates
+                ],
+                dtype=bool,
+            )
+        else:
+            end_idx = num_rows - future_iterations * stride
+            candidates = (
+                np.array(
+                    sorted(index for index in uuid_indices if initial_idx <= index < end_idx),
+                    dtype=np.int64,
+                )
+                if uuid_indices is not None
+                else np.arange(initial_idx, max(end_idx, initial_idx), step_idx, dtype=np.int64)
+            )
+            keep = _keep_anchors(sync_table, candidates, filter, history_iterations, future_iterations, stride)
+
+        anchors = candidates[keep] if len(candidates) else candidates
+        if len(anchors) == 0:
+            return None
+        timestamps_us = np.asarray(sync_table["sync.timestamp_us"].to_numpy(), dtype=np.int64)
+        return LogSceneIndex(
+            log_dir=log_dir,
+            dataset=log_metadata.dataset,
+            split=log_metadata.split,
+            anchor_indices=anchors,
+            anchor_timestamps_us=timestamps_us[anchors],
+            num_rows=num_rows,
+            stride=stride,
+            history_iterations=history_iterations,
+            future_iterations=future_iterations,
+            effective_duration_s=raw_duration_s * stride,
+        )
+    except Exception as error:
+        logger.warning("Error indexing scenes from %s: %s", log_dir, error)
+        logger.debug("Full traceback for %s:", log_dir, exc_info=True)
+        return None
+
+
+def apply_lazy_post_filters(scenes: LazySceneSequence, filter: SceneFilter) -> Sequence[SceneAPI]:
+    """Apply chunking, shuffling and the scene cap without materializing scenes.
+
+    Custom filter functions take a scene, so they force every scene to be built
+    and turn the result back into a plain list.
+
+    :param scenes: The lazy sequence to filter.
+    :param filter: The scene filter.
+    :return: The filtered scenes, lazy unless custom filter functions are set.
+    """
+    if filter.custom_filter_fns is not None:
+        materialized: List[SceneAPI] = list(scenes)
+        for filter_fn in filter.custom_filter_fns:
+            materialized = [scene for scene in materialized if filter_fn(scene)]
+        return _apply_order_filters(materialized, filter)
+
+    order = _apply_order_filters(np.arange(len(scenes), dtype=np.int64), filter)
+    scenes.reorder(np.asarray(order, dtype=np.int64))
+    return scenes
+
+
+def _apply_order_filters(items: Sequence, filter: SceneFilter) -> Sequence:
+    """Apply chunking, shuffling and the scene cap, in the eager builder's order.
+
+    :param items: Scenes, or positions standing in for them.
+    :param filter: The scene filter.
+    :return: The kept items.
+    """
+    if filter.num_chunks is not None and filter.chunk_idx is not None:
+        chunk_size = max(1, len(items) // filter.num_chunks)
+        start = filter.chunk_idx * chunk_size
+        end = start + chunk_size if filter.chunk_idx < filter.num_chunks - 1 else len(items)
+        items = items[start:end]
+
+    if filter.shuffle:
+        # Shuffling positions rather than scenes draws the permutation the eager
+        # builder draws, because the swaps do not depend on the contents.
+        positions = list(range(len(items)))
+        random.shuffle(positions)
+        items = [items[position] for position in positions] if isinstance(items, list) else items[positions]
+
+    if filter.max_num_scenes is not None:
+        items = items[: filter.max_num_scenes]
+    return items

--- a/src/py123d/api/scene/arrow/lazy_scene_sequence.py
+++ b/src/py123d/api/scene/arrow/lazy_scene_sequence.py
@@ -230,7 +230,8 @@ def _null_mask(sync_table: pa.Table, column_name: str, cache: dict) -> np.ndarra
     :return: Boolean array, True where the column is null.
     """
     if column_name not in cache:
-        cache[column_name] = np.asarray(pc.is_null(sync_table.column(column_name)))
+        # to_numpy rather than asarray: the column is chunked, and this is flat by contract.
+        cache[column_name] = pc.is_null(sync_table.column(column_name)).to_numpy(zero_copy_only=False)
     return cache[column_name]
 
 

--- a/src/py123d/api/scene/scene_builder.py
+++ b/src/py123d/api/scene/scene_builder.py
@@ -1,5 +1,5 @@
 import abc
-from typing import List
+from typing import Sequence
 
 from py123d.api.scene.scene_api import SceneAPI
 from py123d.api.scene.scene_filter import SceneFilter
@@ -12,10 +12,12 @@ class SceneBuilder(abc.ABC):
     """
 
     @abc.abstractmethod
-    def get_scenes(self, filter: SceneFilter, executor: Executor) -> List[SceneAPI]:
-        """Returns a list of scenes that match the given filter.
+    def get_scenes(self, filter: SceneFilter, executor: Executor, lazy: bool = False) -> Sequence[SceneAPI]:
+        """Returns the scenes that match the given filter.
 
         :param filter: SceneFilter object to filter the scenes.
         :param executor: Executor to parallelize the scene extraction.
-        :return: List of SceneAPI objects.
+        :param lazy: Whether to build each scene when it is indexed rather than up front. Enumerating a
+            large split this way costs a few arrays per log instead of an object per scene.
+        :return: The matching scenes, as a list unless *lazy* is set.
         """

--- a/src/py123d/api/scene/scene_builder.py
+++ b/src/py123d/api/scene/scene_builder.py
@@ -12,12 +12,13 @@ class SceneBuilder(abc.ABC):
     """
 
     @abc.abstractmethod
-    def get_scenes(self, filter: SceneFilter, executor: Executor, lazy: bool = False) -> Sequence[SceneAPI]:
+    def get_scenes(self, filter: SceneFilter, executor: Executor) -> Sequence[SceneAPI]:
         """Returns the scenes that match the given filter.
+
+        A sequence rather than a list, so an implementation may build its scenes
+        on access instead of up front.
 
         :param filter: SceneFilter object to filter the scenes.
         :param executor: Executor to parallelize the scene extraction.
-        :param lazy: Whether to build each scene when it is indexed rather than up front. Enumerating a
-            large split this way costs a few arrays per log instead of an object per scene.
-        :return: The matching scenes, as a list unless *lazy* is set.
+        :return: The matching scenes.
         """

--- a/tests/unit/api/scene/arrow/test_lazy_scene_sequence.py
+++ b/tests/unit/api/scene/arrow/test_lazy_scene_sequence.py
@@ -1,0 +1,238 @@
+"""The lazy scene path enumerates exactly what the eager path enumerates.
+
+Both paths resolve the same filter semantics — strides, scopes, quantifiers,
+post-filters — from different representations, so every filter shape is checked
+against the eager result rather than against a hand-written expectation.
+"""
+
+import uuid
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import numpy as np
+import pyarrow as pa
+import pytest
+from pyarrow import ipc
+
+from py123d.api.scene.arrow.arrow_scene_builder import ArrowSceneBuilder
+from py123d.api.scene.arrow.lazy_scene_sequence import LazySceneSequence
+from py123d.api.scene.scene_api import SceneAPI
+from py123d.api.scene.scene_filter import SceneFilter
+from py123d.common.execution.sequential_executor import SequentialExecutor
+from py123d.datatypes import LogMetadata
+
+SPLIT_NAME = "test-dataset_train"
+
+
+def _write_log(
+    logs_root: Path,
+    log_name: str,
+    num_rows: int = 24,
+    timestep_us: int = 100_000,
+    front_nulls: Optional[List[int]] = None,
+    rear_nulls: Optional[List[int]] = None,
+    lidar_nulls: Optional[List[int]] = None,
+) -> Path:
+    """Write one log whose modality columns carry the requested gaps.
+
+    :param logs_root: Root the split directory is created under.
+    :param log_name: Name of the log directory.
+    :param num_rows: Rows in the sync table.
+    :param timestep_us: Microseconds between rows.
+    :param front_nulls: Rows where ``camera.front`` is null.
+    :param rear_nulls: Rows where ``camera.rear`` is null.
+    :param lidar_nulls: Rows where ``lidar.top`` is null.
+    :return: The log directory.
+    """
+    log_dir = logs_root / SPLIT_NAME / log_name
+    log_dir.mkdir(parents=True)
+
+    def column(nulls: Optional[List[int]]) -> List[Optional[int]]:
+        values: List[Optional[int]] = list(range(num_rows))
+        for index in nulls or []:
+            values[index] = None
+        return values
+
+    log_metadata = LogMetadata(
+        dataset="test-dataset",
+        split=SPLIT_NAME,
+        log_name=log_name,
+        location="boston",
+        map_metadata=None,
+    )
+    schema = pa.schema(
+        [
+            pa.field("sync.uuid", pa.binary(16)),
+            pa.field("sync.timestamp_us", pa.int64()),
+            pa.field("camera.front", pa.int64()),
+            pa.field("camera.rear", pa.int64()),
+            pa.field("lidar.top", pa.int64()),
+        ]
+    )
+    import msgpack
+
+    schema = schema.with_metadata({b"metadata": msgpack.packb(log_metadata.to_dict(), use_bin_type=True)})
+    table = pa.table(
+        {
+            "sync.uuid": pa.array([uuid.uuid4().bytes for _ in range(num_rows)], type=pa.binary(16)),
+            "sync.timestamp_us": pa.array(np.arange(num_rows, dtype=np.int64) * timestep_us, type=pa.int64()),
+            "camera.front": pa.array(column(front_nulls), type=pa.int64()),
+            "camera.rear": pa.array(column(rear_nulls), type=pa.int64()),
+            "lidar.top": pa.array(column(lidar_nulls), type=pa.int64()),
+        },
+        schema=schema,
+    )
+    with open(log_dir / "sync.arrow", "wb") as file:
+        writer = ipc.new_file(file, table.schema)
+        writer.write_table(table)
+        writer.close()
+    return log_dir
+
+
+@pytest.fixture
+def builder(tmp_path: Path) -> ArrowSceneBuilder:
+    """A builder over a handful of logs with differently shaped gaps.
+
+    :param tmp_path: Temporary directory the logs are written to.
+    :return: The builder.
+    """
+    logs_root = tmp_path / "logs"
+    _write_log(logs_root, "log_complete")
+    _write_log(logs_root, "log_front_gaps", front_nulls=[0, 5, 11, 23])
+    _write_log(logs_root, "log_rear_gaps", rear_nulls=[2, 3, 4, 17])
+    _write_log(logs_root, "log_lidar_gaps", lidar_nulls=list(range(0, 24, 3)))
+    _write_log(logs_root, "log_short", num_rows=6)
+    _write_log(logs_root, "log_no_cameras", front_nulls=list(range(24)), rear_nulls=list(range(24)))
+    return ArrowSceneBuilder(logs_root=logs_root, maps_root=tmp_path / "maps")
+
+
+def _identity(scene: SceneAPI) -> Tuple:
+    """Everything about a scene that enumeration decides.
+
+    :param scene: The scene to describe.
+    :return: The scene's identity as a comparable tuple.
+    """
+    metadata = scene.scene_metadata
+    return (
+        scene.log_name,
+        metadata.initial_idx,
+        metadata.initial_uuid,
+        metadata.num_future_iterations,
+        metadata.num_history_iterations,
+        metadata.target_iteration_stride,
+        round(metadata.iteration_duration_s, 9),
+        round(metadata.future_duration_s, 9),
+        round(metadata.history_duration_s, 9),
+    )
+
+
+FILTERS = {
+    "no requirements": dict(history_num_iterations=1, future_num_iterations=4),
+    "exact key": dict(history_num_iterations=1, future_num_iterations=4, required_scene_modalities=["lidar.top"]),
+    "type all": dict(history_num_iterations=1, future_num_iterations=4, required_scene_modalities=["camera:all"]),
+    "type any": dict(history_num_iterations=1, future_num_iterations=4, required_scene_modalities=["camera:any"]),
+    "scope initial": dict(
+        history_num_iterations=2, future_num_iterations=3, required_scene_modalities=["camera:all@initial"]
+    ),
+    "scope history": dict(
+        history_num_iterations=2, future_num_iterations=3, required_scene_modalities=["camera:all@history"]
+    ),
+    "scope future": dict(
+        history_num_iterations=2, future_num_iterations=3, required_scene_modalities=["camera:any@future"]
+    ),
+    "scope combined": dict(
+        history_num_iterations=2, future_num_iterations=2, required_scene_modalities=["camera:all@initial+future"]
+    ),
+    "several requirements": dict(
+        history_num_iterations=1,
+        future_num_iterations=2,
+        required_scene_modalities=["lidar.top@initial", "camera:all@initial", "camera:any"],
+    ),
+    "absent modality": dict(history_num_iterations=0, future_num_iterations=1, required_scene_modalities=["radar:all"]),
+    "stride": dict(history_num_iterations=1, future_num_iterations=2, target_iteration_stride=3),
+    "stride with gaps": dict(
+        history_num_iterations=1,
+        future_num_iterations=2,
+        target_iteration_stride=2,
+        required_scene_modalities=["camera:all"],
+    ),
+    "step by iterations": dict(history_num_iterations=1, future_num_iterations=3, iteration_threshold=4),
+    "step by seconds": dict(history_num_iterations=1, future_num_iterations=3, timestamp_threshold_s=0.5),
+    "scenes to log end": dict(history_num_iterations=2, required_scene_modalities=["camera:all@history+initial"]),
+    "capped": dict(history_num_iterations=0, future_num_iterations=2, max_num_scenes=7),
+    "chunked": dict(history_num_iterations=0, future_num_iterations=2, num_chunks=3, chunk_idx=1),
+    "last chunk": dict(history_num_iterations=0, future_num_iterations=2, num_chunks=3, chunk_idx=2),
+    "one log": dict(history_num_iterations=1, future_num_iterations=2, log_names=["log_front_gaps"]),
+}
+
+
+@pytest.mark.parametrize("name", list(FILTERS))
+def test_lazy_enumeration_matches_eager(builder: ArrowSceneBuilder, name: str) -> None:
+    """Both paths select the same scenes, in the same order, with the same metadata."""
+    scene_filter = SceneFilter(split_names=[SPLIT_NAME], shuffle=False, **FILTERS[name])
+
+    eager = builder.get_scenes(scene_filter, SequentialExecutor())
+    lazy = builder.get_scenes(scene_filter, SequentialExecutor(), lazy=True)
+
+    assert [_identity(scene) for scene in lazy] == [_identity(scene) for scene in eager]
+
+
+def test_custom_filter_functions_still_apply(builder: ArrowSceneBuilder) -> None:
+    """A filter function takes a scene, so the lazy path materializes and filters."""
+    scene_filter = SceneFilter(
+        split_names=[SPLIT_NAME],
+        shuffle=False,
+        history_num_iterations=1,
+        future_num_iterations=2,
+        custom_filter_fns=[lambda scene: scene.log_name == "log_short"],
+    )
+
+    eager = builder.get_scenes(scene_filter, SequentialExecutor())
+    lazy = builder.get_scenes(scene_filter, SequentialExecutor(), lazy=True)
+
+    assert len(eager) > 0
+    assert [_identity(scene) for scene in lazy] == [_identity(scene) for scene in eager]
+
+
+def test_anchor_keys_match_the_materialized_scenes(builder: ArrowSceneBuilder) -> None:
+    """The pairing keys come from the index, so they must equal what the scenes report."""
+    scene_filter = SceneFilter(
+        split_names=[SPLIT_NAME], shuffle=False, history_num_iterations=1, future_num_iterations=2
+    )
+
+    lazy = builder.get_scenes(scene_filter, SequentialExecutor(), lazy=True)
+    assert isinstance(lazy, LazySceneSequence)
+
+    expected = [(scene.log_name, scene.get_timestamp_at_iteration(0).time_us) for scene in lazy]
+    assert lazy.anchor_keys() == expected
+
+
+def test_indexing_is_stable_and_bounded(builder: ArrowSceneBuilder) -> None:
+    """Indexing builds a scene per call, and out-of-range access is an error."""
+    scene_filter = SceneFilter(
+        split_names=[SPLIT_NAME], shuffle=False, history_num_iterations=1, future_num_iterations=2
+    )
+
+    lazy = builder.get_scenes(scene_filter, SequentialExecutor(), lazy=True)
+
+    assert _identity(lazy[3]) == _identity(lazy[3])
+    assert _identity(lazy[-1]) == _identity(lazy[len(lazy) - 1])
+    assert [_identity(scene) for scene in lazy[2:5]] == [_identity(lazy[index]) for index in (2, 3, 4)]
+    with pytest.raises(IndexError):
+        lazy[len(lazy)]
+
+
+def test_shuffling_draws_the_same_permutation(builder: ArrowSceneBuilder) -> None:
+    """Shuffling positions rather than scenes must reproduce the eager order."""
+    import random
+
+    scene_filter = SceneFilter(
+        split_names=[SPLIT_NAME], shuffle=True, history_num_iterations=1, future_num_iterations=2
+    )
+
+    random.seed(7)
+    eager = builder.get_scenes(scene_filter, SequentialExecutor())
+    random.seed(7)
+    lazy = builder.get_scenes(scene_filter, SequentialExecutor(), lazy=True)
+
+    assert [_identity(scene) for scene in lazy] == [_identity(scene) for scene in eager]

--- a/tests/unit/api/scene/arrow/test_lazy_scene_sequence.py
+++ b/tests/unit/api/scene/arrow/test_lazy_scene_sequence.py
@@ -14,7 +14,7 @@ import pyarrow as pa
 import pytest
 from pyarrow import ipc
 
-from py123d.api.scene.arrow.arrow_scene_builder import ArrowSceneBuilder
+from py123d.api.scene.arrow.arrow_scene_builder import ArrowSceneBuilder, LazyArrowSceneBuilder
 from py123d.api.scene.arrow.lazy_scene_sequence import LazySceneSequence
 from py123d.api.scene.scene_api import SceneAPI
 from py123d.api.scene.scene_filter import SceneFilter
@@ -90,11 +90,11 @@ def _write_log(
 
 
 @pytest.fixture
-def builder(tmp_path: Path) -> ArrowSceneBuilder:
-    """A builder over a handful of logs with differently shaped gaps.
+def builders(tmp_path: Path) -> Tuple[ArrowSceneBuilder, LazyArrowSceneBuilder]:
+    """An eager and a lazy builder over the same logs, with differently shaped gaps.
 
     :param tmp_path: Temporary directory the logs are written to.
-    :return: The builder.
+    :return: The eager builder and the lazy one.
     """
     logs_root = tmp_path / "logs"
     _write_log(logs_root, "log_complete")
@@ -103,7 +103,10 @@ def builder(tmp_path: Path) -> ArrowSceneBuilder:
     _write_log(logs_root, "log_lidar_gaps", lidar_nulls=list(range(0, 24, 3)))
     _write_log(logs_root, "log_short", num_rows=6)
     _write_log(logs_root, "log_no_cameras", front_nulls=list(range(24)), rear_nulls=list(range(24)))
-    return ArrowSceneBuilder(logs_root=logs_root, maps_root=tmp_path / "maps")
+    return (
+        ArrowSceneBuilder(logs_root=logs_root, maps_root=tmp_path / "maps"),
+        LazyArrowSceneBuilder(logs_root=logs_root, maps_root=tmp_path / "maps"),
+    )
 
 
 def _identity(scene: SceneAPI) -> Tuple:
@@ -167,18 +170,20 @@ FILTERS = {
 
 
 @pytest.mark.parametrize("name", list(FILTERS))
-def test_lazy_enumeration_matches_eager(builder: ArrowSceneBuilder, name: str) -> None:
+def test_lazy_enumeration_matches_eager(builders: Tuple[ArrowSceneBuilder, LazyArrowSceneBuilder], name: str) -> None:
     """Both paths select the same scenes, in the same order, with the same metadata."""
+    eager_builder, lazy_builder = builders
     scene_filter = SceneFilter(split_names=[SPLIT_NAME], shuffle=False, **FILTERS[name])
 
-    eager = builder.get_scenes(scene_filter, SequentialExecutor())
-    lazy = builder.get_scenes(scene_filter, SequentialExecutor(), lazy=True)
+    eager = eager_builder.get_scenes(scene_filter, SequentialExecutor())
+    lazy = lazy_builder.get_scenes(scene_filter, SequentialExecutor())
 
     assert [_identity(scene) for scene in lazy] == [_identity(scene) for scene in eager]
 
 
-def test_custom_filter_functions_still_apply(builder: ArrowSceneBuilder) -> None:
+def test_custom_filter_functions_still_apply(builders: Tuple[ArrowSceneBuilder, LazyArrowSceneBuilder]) -> None:
     """A filter function takes a scene, so the lazy path materializes and filters."""
+    eager_builder, lazy_builder = builders
     scene_filter = SceneFilter(
         split_names=[SPLIT_NAME],
         shuffle=False,
@@ -187,33 +192,35 @@ def test_custom_filter_functions_still_apply(builder: ArrowSceneBuilder) -> None
         custom_filter_fns=[lambda scene: scene.log_name == "log_short"],
     )
 
-    eager = builder.get_scenes(scene_filter, SequentialExecutor())
-    lazy = builder.get_scenes(scene_filter, SequentialExecutor(), lazy=True)
+    eager = eager_builder.get_scenes(scene_filter, SequentialExecutor())
+    lazy = lazy_builder.get_scenes(scene_filter, SequentialExecutor())
 
     assert len(eager) > 0
     assert [_identity(scene) for scene in lazy] == [_identity(scene) for scene in eager]
 
 
-def test_anchor_keys_match_the_materialized_scenes(builder: ArrowSceneBuilder) -> None:
+def test_anchor_keys_match_the_materialized_scenes(builders: Tuple[ArrowSceneBuilder, LazyArrowSceneBuilder]) -> None:
     """The pairing keys come from the index, so they must equal what the scenes report."""
+    eager_builder, lazy_builder = builders
     scene_filter = SceneFilter(
         split_names=[SPLIT_NAME], shuffle=False, history_num_iterations=1, future_num_iterations=2
     )
 
-    lazy = builder.get_scenes(scene_filter, SequentialExecutor(), lazy=True)
+    lazy = lazy_builder.get_scenes(scene_filter, SequentialExecutor())
     assert isinstance(lazy, LazySceneSequence)
 
     expected = [(scene.log_name, scene.get_timestamp_at_iteration(0).time_us) for scene in lazy]
     assert lazy.anchor_keys() == expected
 
 
-def test_indexing_is_stable_and_bounded(builder: ArrowSceneBuilder) -> None:
+def test_indexing_is_stable_and_bounded(builders: Tuple[ArrowSceneBuilder, LazyArrowSceneBuilder]) -> None:
     """Indexing builds a scene per call, and out-of-range access is an error."""
+    eager_builder, lazy_builder = builders
     scene_filter = SceneFilter(
         split_names=[SPLIT_NAME], shuffle=False, history_num_iterations=1, future_num_iterations=2
     )
 
-    lazy = builder.get_scenes(scene_filter, SequentialExecutor(), lazy=True)
+    lazy = lazy_builder.get_scenes(scene_filter, SequentialExecutor())
 
     assert _identity(lazy[3]) == _identity(lazy[3])
     assert _identity(lazy[-1]) == _identity(lazy[len(lazy) - 1])
@@ -222,17 +229,18 @@ def test_indexing_is_stable_and_bounded(builder: ArrowSceneBuilder) -> None:
         lazy[len(lazy)]
 
 
-def test_shuffling_draws_the_same_permutation(builder: ArrowSceneBuilder) -> None:
+def test_shuffling_draws_the_same_permutation(builders: Tuple[ArrowSceneBuilder, LazyArrowSceneBuilder]) -> None:
     """Shuffling positions rather than scenes must reproduce the eager order."""
     import random
 
+    eager_builder, lazy_builder = builders
     scene_filter = SceneFilter(
         split_names=[SPLIT_NAME], shuffle=True, history_num_iterations=1, future_num_iterations=2
     )
 
     random.seed(7)
-    eager = builder.get_scenes(scene_filter, SequentialExecutor())
+    eager = eager_builder.get_scenes(scene_filter, SequentialExecutor())
     random.seed(7)
-    lazy = builder.get_scenes(scene_filter, SequentialExecutor(), lazy=True)
+    lazy = lazy_builder.get_scenes(scene_filter, SequentialExecutor())
 
     assert [_identity(scene) for scene in lazy] == [_identity(scene) for scene in eager]


### PR DESCRIPTION
# Lazy scene enumeration

`get_scenes(..., lazy=True)` keeps a split as a few numpy arrays per log and builds a scene in `__getitem__`, instead of one `SceneMetadata` and `ArrowSceneAPI` per frame up front. The default stays eager.

# Log discovery

Log discovery probes for `sync.arrow` instead of listing each log directory. Not opt-in, output identical.

## Gain

8800 logs, 1.2 M scenes: enumeration **291 s → 8 s**, discovery **14.8 s → 1.5 s**.