### PR TITLE
Camera exposure/provenance metadata; per-block display gamma; radar viewer fixes

### DIFF
--- a/src/py123d/api/scene/arrow/modalities/arrow_camera.py
+++ b/src/py123d/api/scene/arrow/modalities/arrow_camera.py
@@ -80,6 +80,9 @@ class ArrowCameraWriter(ArrowBaseModalityWriter):
                 (f"{metadata.modality_key}.timestamp_us", pa.int64()),
                 (f"{metadata.modality_key}.data", data_type),
                 (f"{metadata.modality_key}.camera_to_global_se3", pa.list_(pa.float64(), len(PoseSE3Index))),
+                # Per-frame exposure normalization gain (see Camera.exposure_factor); null
+                # for datasets that do not provide it.
+                (f"{metadata.modality_key}.exposure_factor", pa.float32()),
             ]
         )
         schema = add_metadata_to_arrow_schema(schema, metadata)
@@ -119,6 +122,7 @@ class ArrowCameraWriter(ArrowBaseModalityWriter):
                 f"{self._metadata.modality_key}.timestamp_us": [modality.timestamp.time_us],
                 f"{self._metadata.modality_key}.data": [data],
                 f"{self._metadata.modality_key}.camera_to_global_se3": [modality.camera_to_global_se3],
+                f"{self._metadata.modality_key}.exposure_factor": [modality.exposure_factor],
             }
         )
 
@@ -317,6 +321,14 @@ def _deserialize_camera(
     camera_to_global_se3_data = arrow_table[camera_extrinsic_column][index].as_py()
     timestamp_data = arrow_table[camera_timestamp_column][index].as_py()
 
+    # Optional column; absent in logs written before it was added.
+    exposure_factor_column = f"{modality_key}.exposure_factor"
+    exposure_factor = (
+        arrow_table[exposure_factor_column][index].as_py()
+        if exposure_factor_column in arrow_table.column_names
+        else None
+    )
+
     if table_data is None or camera_to_global_se3_data is None:
         return None
     image = _deserialize_data_column(
@@ -334,6 +346,7 @@ def _deserialize_camera(
         image=image,
         camera_to_global_se3=camera_to_global_se3,
         timestamp=Timestamp.from_us(timestamp_data),
+        exposure_factor=exposure_factor,
     )
 
 

--- a/src/py123d/datatypes/sensors/base_camera.py
+++ b/src/py123d/datatypes/sensors/base_camera.py
@@ -302,7 +302,7 @@ class BaseCameraMetadata(BaseModalityMetadata, abc.ABC):
 class Camera(BaseModality):
     """A camera observation: image, extrinsic pose, timestamp, and model-specific metadata."""
 
-    __slots__ = ("_metadata", "_image", "_camera_to_global_se3", "_timestamp")
+    __slots__ = ("_metadata", "_image", "_camera_to_global_se3", "_timestamp", "_exposure_factor")
 
     def __init__(
         self,
@@ -310,6 +310,7 @@ class Camera(BaseModality):
         image: npt.NDArray[np.uint8],
         camera_to_global_se3: PoseSE3,
         timestamp: Timestamp,
+        exposure_factor: Optional[float] = None,
     ) -> None:
         """Initialize a Camera instance.
 
@@ -317,16 +318,29 @@ class Camera(BaseModality):
         :param image: The image captured by the camera.
         :param camera_to_global_se3: The extrinsic pose of the camera in global coordinates.
         :param timestamp: The timestamp of the image capture.
+        :param exposure_factor: Per-frame exposure normalization gain applied upstream of
+            the stored image, if known (see :attr:`exposure_factor`).
         """
         self._metadata = metadata
         self._image = image
         self._camera_to_global_se3 = camera_to_global_se3
         self._timestamp = timestamp
+        self._exposure_factor = exposure_factor
 
     @property
     def timestamp(self) -> Timestamp:
         """The :class:`~py123d.datatypes.Timestamp` of the image capture."""
         return self._timestamp
+
+    @property
+    def exposure_factor(self) -> Optional[float]:
+        """Per-frame exposure normalization gain applied upstream of the stored image, if known.
+
+        Recording pipelines with auto-exposure normalization (e.g. Kesai) scale the linear
+        sensor signal by this gain before encoding; dividing the linearized image by it
+        recovers the absolute radiance scale. None when the dataset does not provide it.
+        """
+        return self._exposure_factor
 
     @property
     def metadata(self) -> BaseCameraMetadata:

--- a/src/py123d/datatypes/sensors/ftheta_camera.py
+++ b/src/py123d/datatypes/sensors/ftheta_camera.py
@@ -153,6 +153,7 @@ class FThetaCameraMetadata(BaseCameraMetadata):
         "_height",
         "_camera_to_imu_se3",
         "_isp",
+        "_vendor_info",
     )
 
     def __init__(
@@ -164,6 +165,7 @@ class FThetaCameraMetadata(BaseCameraMetadata):
         height: int,
         camera_to_imu_se3: PoseSE3,
         isp: Optional[Dict[str, Any]] = None,
+        vendor_info: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Initialize the f-theta camera metadata.
 
@@ -177,6 +179,8 @@ class FThetaCameraMetadata(BaseCameraMetadata):
             level, color correction matrix, tone curve control points). Describes the
             color transform a viewer should apply on the fly to the stored images; the
             stored images themselves are raw. None if no such transform is defined.
+        :param vendor_info: Optional hardware provenance (e.g. sensor type and serializer
+            serial number), as reported by the recording pipeline. None if unknown.
         """
         self._camera_name = camera_name
         self._camera_id = camera_id
@@ -185,6 +189,7 @@ class FThetaCameraMetadata(BaseCameraMetadata):
         self._height = height
         self._camera_to_imu_se3 = camera_to_imu_se3
         self._isp = isp
+        self._vendor_info = vendor_info
 
     @classmethod
     def from_dict(cls, data_dict: Dict[str, Any]) -> FThetaCameraMetadata:
@@ -204,6 +209,7 @@ class FThetaCameraMetadata(BaseCameraMetadata):
             height=data_dict["height"],
             camera_to_imu_se3=PoseSE3.from_list(data_dict["camera_to_imu_se3"]),
             isp=data_dict.get("isp"),
+            vendor_info=data_dict.get("vendor_info"),
         )
 
     @property
@@ -245,6 +251,16 @@ class FThetaCameraMetadata(BaseCameraMetadata):
     def isp(self) -> Optional[Dict[str, Any]]:
         """Display-ISP parameters a viewer should apply to the stored raw images, if any."""
         return self._isp
+
+    @property
+    def vendor_info(self) -> Optional[Dict[str, Any]]:
+        """Hardware provenance reported by the recording pipeline, if any."""
+        return self._vendor_info
+
+    @vendor_info.setter
+    def vendor_info(self, vendor_info: Optional[Dict[str, Any]]) -> None:
+        """Settable so parsers can attach provenance read from the first decoded frame."""
+        self._vendor_info = vendor_info
 
     def project_to_image(
         self,
@@ -376,4 +392,6 @@ class FThetaCameraMetadata(BaseCameraMetadata):
         data_dict["camera_to_imu_se3"] = self._camera_to_imu_se3.to_list()
         if self._isp is not None:
             data_dict["isp"] = self._isp
+        if self._vendor_info is not None:
+            data_dict["vendor_info"] = self._vendor_info
         return data_dict

--- a/src/py123d/datatypes/sensors/radar.py
+++ b/src/py123d/datatypes/sensors/radar.py
@@ -394,6 +394,16 @@ class Radar(BaseModality):
         return self._feature(RadarFeature.RCS)  # type: ignore
 
     @property
+    def snr(self) -> Optional[npt.NDArray[np.float32]]:
+        """The point cloud as an Nx1 array of signal-to-noise ratios, if available."""
+        return self._feature(RadarFeature.SNR)  # type: ignore
+
+    @property
+    def confidence(self) -> Optional[npt.NDArray[np.float32]]:
+        """The point cloud as an Nx1 array of detection confidences (dataset-native scale), if available."""
+        return self._feature(RadarFeature.CONFIDENCE)  # type: ignore
+
+    @property
     def velocity(self) -> Optional[npt.NDArray[np.float32]]:
         """The point cloud as an Nx2 array of raw (vx, vy) velocities in m/s, if available."""
         velocity: Optional[npt.NDArray[np.float32]] = None

--- a/src/py123d/parser/base_dataset_parser.py
+++ b/src/py123d/parser/base_dataset_parser.py
@@ -202,6 +202,7 @@ class ParsedCamera(BaseModality):
         dataset_root: Optional[Union[str, Path]] = None,
         relative_path: Optional[Union[str, Path]] = None,
         byte_string: Optional[bytes] = None,
+        exposure_factor: Optional[float] = None,
     ) -> None:
         self._metadata = metadata
         self._timestamp = timestamp
@@ -210,6 +211,7 @@ class ParsedCamera(BaseModality):
         self._dataset_root = dataset_root
         self._relative_path = relative_path
         self._byte_string = byte_string
+        self._exposure_factor = exposure_factor
 
         assert self.has_file_path or self.has_byte_string, (
             "Either file path or byte string must be provided for ParsedCamera."
@@ -250,3 +252,12 @@ class ParsedCamera(BaseModality):
     @property
     def has_byte_string(self) -> bool:
         return self._byte_string is not None
+
+    @property
+    def exposure_factor(self) -> Optional[float]:
+        """Per-frame exposure normalization gain applied upstream of the stored image, if known.
+
+        Datasets whose recording pipeline auto-normalizes exposure (e.g. Kesai) record the
+        applied gain here so absolute radiance can be recovered; None when not provided.
+        """
+        return self._exposure_factor

--- a/src/py123d/visualization/matplotlib/radar.py
+++ b/src/py123d/visualization/matplotlib/radar.py
@@ -5,21 +5,23 @@ import numpy as np
 import numpy.typing as npt
 
 from py123d.datatypes import Radar
-from py123d.datatypes.sensors.radar import RadarFeature
 from py123d.visualization.matplotlib.lidar import _continuous_colormap, _discrete_colormap
 
 logger = logging.getLogger(__name__)
 
+# Signal-quality features (rcs, snr, confidence) lead the list: they are the most relevant
+# radar statistics and belong next to each other in viewer dropdowns.
 RadarColorFeature = Literal[
     "none",
+    "rcs",
+    "snr",
+    "confidence",
     "height",
     "distance",
     "ids",
     "cluster_id",
-    "rcs",
     "velocity",
     "velocity_comp",
-    "snr",
     "timestamps",
 ]
 
@@ -33,8 +35,8 @@ def get_radar_pc_color(
     """Compute per-point RGB colors for a radar point cloud based on a feature.
 
     Mirrors :func:`py123d.visualization.matplotlib.lidar.get_lidar_pc_color`, but exposes radar-native
-    features (RCS, velocity magnitude, SNR, cluster id). Velocity options color by the 2D speed
-    magnitude. A feature that is unavailable on the cloud falls back to the default color.
+    features (RCS, SNR, confidence, velocity magnitude, cluster id). Velocity options color by the 2D
+    speed magnitude. A feature that is unavailable on the cloud falls back to the default color.
 
     :param radar: Radar object containing the point cloud and its metadata.
     :param color_feature: The feature to color the point cloud by.
@@ -76,8 +78,9 @@ def get_radar_pc_color(
         "ids": radar.ids,
         "cluster_id": radar.cluster_id,
         "rcs": radar.rcs,
+        "snr": radar.snr,
+        "confidence": radar.confidence,
         "timestamps": radar.timestamps,
-        "snr": (radar.point_cloud_features or {}).get(RadarFeature.SNR.serialize()),
     }
 
     values = feature_accessor.get(color_feature)
@@ -88,7 +91,7 @@ def get_radar_pc_color(
     if color_feature in discrete_features:
         return _discrete_colormap(values)
 
-    # Continuous features (rcs, timestamps, snr).
+    # Continuous features (rcs, snr, confidence, timestamps).
     if values.dtype == np.uint8:
         values = values.astype(np.float32)
     elif values.dtype == np.int64:

--- a/src/py123d/visualization/viser/elements/lidar_element.py
+++ b/src/py123d/visualization/viser/elements/lidar_element.py
@@ -234,9 +234,15 @@ class LidarElement(ViewerElement):
     def _on_visibility_changed(self, _) -> None:
         assert self._gui_visible is not None
         self._config.visible = self._gui_visible.value
-        for handle in self._handles.values():
-            if handle is not None:
-                handle.visible = self._gui_visible.value
+        if self._gui_visible.value:
+            # A cloud may not exist yet when the element was launched hidden (update()
+            # skips hidden elements); rebuild for the current iteration instead of only
+            # toggling handle visibility.
+            self.update(self._current_iteration)
+        else:
+            for handle in self._handles.values():
+                if handle is not None:
+                    handle.visible = False
         if not self._gui_visible.value:
             self._remove_sensor_frames()
 

--- a/src/py123d/visualization/viser/elements/radar_element.py
+++ b/src/py123d/visualization/viser/elements/radar_element.py
@@ -20,16 +20,19 @@ from py123d.visualization.viser.utils.view_utils import get_scene_center_pose
 
 logger = logging.getLogger(__name__)
 
+# Signal-quality features (rcs, snr, confidence) directly after "none": they are the most
+# relevant radar statistics and stay grouped in the dropdown.
 _RADAR_COLOR_OPTIONS = (
     "none",
+    "rcs",
+    "snr",
+    "confidence",
     "height",
     "distance",
     "ids",
     "cluster_id",
-    "rcs",
     "velocity",
     "velocity_comp",
-    "snr",
     "timestamps",
 )
 
@@ -44,14 +47,15 @@ class RadarConfig:
     point_shape: Literal["square", "diamond", "circle", "rounded", "sparkle"] = "circle"
     point_color: Literal[
         "none",
+        "rcs",
+        "snr",
+        "confidence",
         "height",
         "distance",
         "ids",
         "cluster_id",
-        "rcs",
         "velocity",
         "velocity_comp",
-        "snr",
         "timestamps",
     ] = "none"
     stride_step: int = 1
@@ -209,10 +213,15 @@ class RadarElement(ViewerElement):
     def _on_visibility_changed(self, _) -> None:
         assert self._gui_visible is not None
         self._config.visible = self._gui_visible.value
-        for handle in self._handles.values():
-            if handle is not None:
-                handle.visible = self._gui_visible.value
-        if not self._gui_visible.value:
+        if self._gui_visible.value:
+            # The element starts hidden, so no cloud may exist yet (update() skips hidden
+            # elements); rebuilding for the current iteration creates and shows them.
+            # Toggling handle.visible alone would show nothing until the next frame change.
+            self.update(self._current_iteration)
+        else:
+            for handle in self._handles.values():
+                if handle is not None:
+                    handle.visible = False
             self._remove_sensor_frames()
 
     def _on_coloring_changed(self, _) -> None:

--- a/src/py123d/visualization/viser/utils/display_isp.py
+++ b/src/py123d/visualization/viser/utils/display_isp.py
@@ -1,10 +1,11 @@
 """On-the-fly display ISP for raw-stored camera images.
 
 Datasets can attach a display-ISP block to their camera metadata (see
-``FThetaCameraMetadata.isp``): black/white level, a 3x3 color correction matrix and
-per-channel tone curves given as sparse control points. The stored images carry no color
-processing (linear data under the storage gamma below, with the ISP block's levels defined
-in that linearized domain); this module applies the color transform at display time.
+``FThetaCameraMetadata.isp``): black/white level, a 3x3 color correction matrix,
+per-channel tone curves given as sparse control points, and optionally the storage gamma
+of the stored images (``storage_gamma``, default 2.2). The stored images carry no color
+processing (gamma-encoded linear data, with the ISP block's levels defined in the
+linearized domain); this module applies the color transform at display time.
 
 The pipeline is four OpenCV calls, each SIMD-vectorized and multi-threaded:
 ``cv2.LUT`` (decode gamma + black/white normalization into a uint16 linear domain),
@@ -21,8 +22,10 @@ import numpy as np
 import numpy.typing as npt
 from scipy.interpolate import PchipInterpolator
 
-# Stored images are sRGB-style gamma encoded with this exponent.
-_STORAGE_GAMMA: float = 2.2
+# Default storage-gamma exponent for ISP blocks that do not declare one (sRGB-style).
+# Kesai logs store the vehicle ISP's gamma-1/3 tone mapping verbatim and declare
+# storage_gamma = 3.0 in their block.
+_DEFAULT_STORAGE_GAMMA: float = 2.2
 
 # LUTs per distinct ISP block, keyed by a content hash.
 _LUT_CACHE: Dict[int, Tuple[npt.NDArray[np.uint16], npt.NDArray[np.float32], npt.NDArray[np.uint8]]] = {}
@@ -32,6 +35,7 @@ def _isp_cache_key(isp: Dict[str, Any]) -> int:
     tone = isp["tone_curve"]
     return hash(
         (
+            float(isp.get("storage_gamma", _DEFAULT_STORAGE_GAMMA)),
             float(isp["black_level"]),
             float(isp["white_level"]),
             tuple(tuple(row) for row in isp["ccm"]),
@@ -47,13 +51,14 @@ def _build_luts(
     isp: Dict[str, Any],
 ) -> Tuple[npt.NDArray[np.uint16], npt.NDArray[np.float32], npt.NDArray[np.uint8]]:
     """Expand an ISP block into the lookup structures used per frame."""
+    storage_gamma = float(isp.get("storage_gamma", _DEFAULT_STORAGE_GAMMA))
     black = float(isp["black_level"])
     white = float(isp["white_level"])
 
     # uint8 pixel -> normalized linear value (decode storage gamma, remove pedestal),
     # quantized to uint16 so the color matrix runs in an integer saturating domain.
     encoded = np.arange(256, dtype=np.float64) / 255.0
-    linear = np.clip((encoded**_STORAGE_GAMMA - black) / (white - black), 0.0, 1.0)
+    linear = np.clip((encoded**storage_gamma - black) / (white - black), 0.0, 1.0)
     input_lut = np.round(linear * 65535.0).astype(np.uint16).reshape(1, 256, 1)
 
     ccm = np.asarray(isp["ccm"], dtype=np.float32)

--- a/src/py123d/visualization/viser/utils/display_isp.py
+++ b/src/py123d/visualization/viser/utils/display_isp.py
@@ -2,10 +2,11 @@
 
 Datasets can attach a display-ISP block to their camera metadata (see
 ``FThetaCameraMetadata.isp``): black/white level, a 3x3 color correction matrix,
-per-channel tone curves given as sparse control points, and optionally the storage gamma
-of the stored images (``storage_gamma``, default 2.2). The stored images carry no color
-processing (gamma-encoded linear data, with the ISP block's levels defined in the
-linearized domain); this module applies the color transform at display time.
+per-channel tone curves given as sparse control points, and optionally ``storage_gamma``
+(default 2.2) — the exponent applied to stored values to reach the domain the block's
+parameters are defined in (1.0 for blocks fitted directly on the stored values). The
+stored images carry no color processing; this module applies the color transform at
+display time.
 
 The pipeline is four OpenCV calls, each SIMD-vectorized and multi-threaded:
 ``cv2.LUT`` (decode gamma + black/white normalization into a uint16 linear domain),
@@ -22,9 +23,8 @@ import numpy as np
 import numpy.typing as npt
 from scipy.interpolate import PchipInterpolator
 
-# Default storage-gamma exponent for ISP blocks that do not declare one (sRGB-style).
-# Kesai logs store the vehicle ISP's gamma-1/3 tone mapping verbatim and declare
-# storage_gamma = 3.0 in their block.
+# Default exponent for ISP blocks that do not declare storage_gamma (sRGB-style). Kesai
+# blocks declare 1.0: their parameters are fitted directly on the stored values.
 _DEFAULT_STORAGE_GAMMA: float = 2.2
 
 # LUTs per distinct ISP block, keyed by a content hash.

--- a/src/py123d/visualization/viser/utils/display_isp.py
+++ b/src/py123d/visualization/viser/utils/display_isp.py
@@ -2,8 +2,9 @@
 
 Datasets can attach a display-ISP block to their camera metadata (see
 ``FThetaCameraMetadata.isp``): black/white level, a 3x3 color correction matrix and
-per-channel tone curves given as sparse control points. The stored images are raw
-(gamma-encoded sensor data); this module applies the color transform at display time.
+per-channel tone curves given as sparse control points. The stored images carry no color
+processing (linear data under the storage gamma below, with the ISP block's levels defined
+in that linearized domain); this module applies the color transform at display time.
 
 The pipeline is four OpenCV calls, each SIMD-vectorized and multi-threaded:
 ``cv2.LUT`` (decode gamma + black/white normalization into a uint16 linear domain),


### PR DESCRIPTION
Companion to the corrected Kesai camera conversion in py123d-dev (`ec49cdf`...`4cc9b09`); full pipeline documentation lives in py123d-dev `scripts/kesai/KESAI.md`. Three independent parts, all backward compatible:

## Camera data model
- `ParsedCamera` / `Camera` carry an optional per-frame `exposure_factor` — the auto-exposure gain the recording pipeline applied upstream; dividing the linearized image by it recovers absolute radiance. Stored as a nullable float32 Arrow column; logs written before the column read back as `None` (round trip verified both ways).
- `FThetaCameraMetadata` carries optional `vendor_info` (hardware provenance: sensor type, serializer serial), serialized with the metadata.

## Display ISP
- The ISP metadata block can declare `storage_gamma` — the exponent mapping stored values into the domain the block's parameters are defined in (default 2.2, unchanged for existing logs; Kesai blocks declare 1.0 because their parameters were fitted directly on the stored gamma-1/3 values). Part of the LUT cache key.

## Viser radar/lidar
- Fix: enabling *Visible* on an element launched hidden now rebuilds the point clouds for the current iteration. Previously only existing handles were toggled, so radar (hidden by default) showed nothing until the next frame change regardless of coloring.
- Radar coloring gains `confidence`; `rcs`/`snr`/`confidence` are grouped directly after `none` in the dropdown as the most relevant radar statistics. `Radar` exposes `snr`/`confidence` accessors analogous to `rcs`.

## Testing
1960 unit tests pass; functional round trips for the new Arrow column (including column-less old logs) and metadata serialization; display output verified pixel-close (1.3 DN mean) against the established Kesai rendering on a real recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)