### PR TITLE
GNSS: optional solution-quality fields

### DIFF
--- a/src/py123d/api/scene/arrow/modalities/arrow_gnss.py
+++ b/src/py123d/api/scene/arrow/modalities/arrow_gnss.py
@@ -12,6 +12,18 @@ from py123d.datatypes.time.timestamp import Timestamp
 
 _LLA_SIZE: int = 3
 _COVARIANCE_SIZE: int = 9
+_VELOCITY_SIZE: int = 3
+
+# Written only when GnssMetadata.has_solution_quality is set, so logs converted before these
+# fields existed keep their original schema and still load.
+_SOLUTION_QUALITY_FIELDS: tuple = (
+    ("num_satellites", pa.int32()),
+    ("fix_type", pa.int32()),
+    ("horizontal_accuracy", pa.float64()),
+    ("vertical_accuracy", pa.float64()),
+    ("position_dop", pa.float64()),
+    ("velocity_ned", pa.list_(pa.float64(), _VELOCITY_SIZE)),
+)
 
 # ------------------------------------------------------------------------------------------------------------------
 # Writer
@@ -37,17 +49,18 @@ class ArrowGnssWriter(ArrowBaseModalityWriter):
         self._metadata = metadata
         self._key = metadata.modality_key
 
-        schema = pa.schema(
-            [
-                (f"{self._key}.timestamp_us", pa.int64()),
-                (f"{self._key}.lla", pa.list_(pa.float64(), _LLA_SIZE)),
-                (f"{self._key}.position_covariance", pa.list_(pa.float64(), _COVARIANCE_SIZE)),
-                (f"{self._key}.position_covariance_type", pa.int32()),
-                (f"{self._key}.status", pa.int32()),
-                (f"{self._key}.service", pa.int32()),
-            ]
-        )
-        schema = add_metadata_to_arrow_schema(schema, metadata)
+        fields = [
+            (f"{self._key}.timestamp_us", pa.int64()),
+            (f"{self._key}.lla", pa.list_(pa.float64(), _LLA_SIZE)),
+            (f"{self._key}.position_covariance", pa.list_(pa.float64(), _COVARIANCE_SIZE)),
+            (f"{self._key}.position_covariance_type", pa.int32()),
+            (f"{self._key}.status", pa.int32()),
+            (f"{self._key}.service", pa.int32()),
+        ]
+        if metadata.has_solution_quality:
+            fields.extend((f"{self._key}.{name}", dtype) for name, dtype in _SOLUTION_QUALITY_FIELDS)
+
+        schema = add_metadata_to_arrow_schema(pa.schema(fields), metadata)
         super().__init__(
             file_path=log_dir / f"{self._key}.arrow",
             schema=schema,
@@ -59,16 +72,24 @@ class ArrowGnssWriter(ArrowBaseModalityWriter):
     def write_modality(self, modality: BaseModality) -> None:
         assert isinstance(modality, Gnss), f"Expected Gnss, got {type(modality)}"
         covariance = modality.position_covariance
-        self.write_batch(
-            {
-                f"{self._key}.timestamp_us": [modality.timestamp.time_us],
-                f"{self._key}.lla": [modality.lla],
-                f"{self._key}.position_covariance": [covariance if covariance is not None else None],
-                f"{self._key}.position_covariance_type": [modality.position_covariance_type],
-                f"{self._key}.status": [modality.status],
-                f"{self._key}.service": [modality.service],
-            }
-        )
+        row: dict = {
+            f"{self._key}.timestamp_us": [modality.timestamp.time_us],
+            f"{self._key}.lla": [modality.lla],
+            f"{self._key}.position_covariance": [covariance if covariance is not None else None],
+            f"{self._key}.position_covariance_type": [modality.position_covariance_type],
+            f"{self._key}.status": [modality.status],
+            f"{self._key}.service": [modality.service],
+        }
+        if self._metadata.has_solution_quality:
+            for name, _ in _SOLUTION_QUALITY_FIELDS:
+                row[f"{self._key}.{name}"] = [getattr(modality, name)]
+        else:
+            for name, _ in _SOLUTION_QUALITY_FIELDS:
+                assert getattr(modality, name) is None, (
+                    f"Fix carries {name} but GnssMetadata.has_solution_quality is False; "
+                    "the value would be silently dropped."
+                )
+        self.write_batch(row)
 
 
 # ------------------------------------------------------------------------------------------------------------------
@@ -90,8 +111,16 @@ class ArrowGnssReader(ArrowBaseModalityReader):
         assert isinstance(metadata, GnssMetadata), f"Expected GnssMetadata, got {type(metadata)}"
         key = metadata.modality_key
 
+        def _optional(column: str) -> Optional[Any]:
+            # Absent by schema design for logs converted without the solution-quality fields.
+            full_name = f"{key}.{column}"
+            if full_name not in table.column_names:
+                return None
+            return table[full_name][index].as_py()
+
         lla = table[f"{key}.lla"][index].as_py()
         covariance = table[f"{key}.position_covariance"][index].as_py()
+        velocity_ned = _optional("velocity_ned")
         return Gnss(
             timestamp=Timestamp.from_us(table[f"{key}.timestamp_us"][index].as_py()),
             metadata=metadata,
@@ -102,6 +131,12 @@ class ArrowGnssReader(ArrowBaseModalityReader):
             position_covariance_type=table[f"{key}.position_covariance_type"][index].as_py(),
             status=table[f"{key}.status"][index].as_py(),
             service=table[f"{key}.service"][index].as_py(),
+            num_satellites=_optional("num_satellites"),
+            fix_type=_optional("fix_type"),
+            horizontal_accuracy=_optional("horizontal_accuracy"),
+            vertical_accuracy=_optional("vertical_accuracy"),
+            position_dop=_optional("position_dop"),
+            velocity_ned=np.asarray(velocity_ned, dtype=np.float64) if velocity_ned is not None else None,
         )
 
     @staticmethod
@@ -116,9 +151,9 @@ class ArrowGnssReader(ArrowBaseModalityReader):
     ) -> Optional[Any]:
         full_column_name = f"{metadata.modality_key}.{column}"
         if full_column_name not in table.column_names:
-            raise ValueError(
-                f"Column '{full_column_name}' not found in Arrow table for modality '{metadata.modality_key}'"
-            )
+            # Columns can be legitimately absent by schema design (has_solution_quality flag);
+            # return None like the sibling readers do.
+            return None
         value = table[full_column_name][index].as_py()
         if deserialize and value is not None and column == "timestamp_us":
             value = Timestamp.from_us(value)

--- a/src/py123d/datatypes/sensors/gnss.py
+++ b/src/py123d/datatypes/sensors/gnss.py
@@ -20,7 +20,7 @@ class GnssMetadata(BaseModalityMetadata):
     coordinates.
     """
 
-    __slots__ = ("_gnss_name", "_gnss_id", "_gnss_to_imu_se3", "_datum_lla")
+    __slots__ = ("_gnss_name", "_gnss_id", "_gnss_to_imu_se3", "_datum_lla", "_has_solution_quality")
 
     def __init__(
         self,
@@ -28,6 +28,7 @@ class GnssMetadata(BaseModalityMetadata):
         gnss_id: Optional[str] = None,
         gnss_to_imu_se3: PoseSE3 = PoseSE3.identity(),
         datum_lla: Optional[Tuple[float, float, float]] = None,
+        has_solution_quality: bool = False,
     ):
         """Initialize GNSS metadata.
 
@@ -37,11 +38,15 @@ class GnssMetadata(BaseModalityMetadata):
         :param gnss_to_imu_se3: The extrinsic pose of the GNSS antenna relative to the IMU frame.
         :param datum_lla: Optional (latitude_deg, longitude_deg, altitude_m) reference point of
             the log's local metric frame.
+        :param has_solution_quality: Whether the receiver reports the solution-quality fields
+            (satellite count, fix type, reported accuracies, DOP, NED velocity). Logs converted
+            before these fields existed leave it False and store no such columns.
         """
         self._gnss_name = gnss_name
         self._gnss_id = gnss_id
         self._gnss_to_imu_se3 = gnss_to_imu_se3
         self._datum_lla = datum_lla
+        self._has_solution_quality = has_solution_quality
 
     @property
     def gnss_name(self) -> str:
@@ -64,6 +69,11 @@ class GnssMetadata(BaseModalityMetadata):
         return self._datum_lla
 
     @property
+    def has_solution_quality(self) -> bool:
+        """Whether the receiver reports the solution-quality fields."""
+        return self._has_solution_quality
+
+    @property
     def modality_type(self) -> ModalityType:
         return ModalityType.GNSS
 
@@ -84,6 +94,7 @@ class GnssMetadata(BaseModalityMetadata):
             gnss_id=data_dict.get("gnss_id"),
             gnss_to_imu_se3=PoseSE3.from_list(data_dict["gnss_to_imu_se3"]),
             datum_lla=tuple(datum) if datum is not None else None,
+            has_solution_quality=data_dict.get("has_solution_quality", False),
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -96,6 +107,7 @@ class GnssMetadata(BaseModalityMetadata):
             "gnss_id": self._gnss_id,
             "gnss_to_imu_se3": self._gnss_to_imu_se3.tolist(),
             "datum_lla": list(self._datum_lla) if self._datum_lla is not None else None,
+            "has_solution_quality": self._has_solution_quality,
         }
 
 
@@ -105,6 +117,14 @@ class Gnss(BaseModality):
     Field semantics follow ``sensor_msgs/msg/NavSatFix``: WGS-84 geodetic coordinates, ENU
     position covariance in m^2, and the NavSatStatus fix status / service constants
     (status: -1 no fix, 0 fix, 1 SBAS fix, 2 GBAS fix).
+
+    The solution-quality fields (:attr:`num_satellites`, :attr:`fix_type`,
+    :attr:`horizontal_accuracy`, :attr:`vertical_accuracy`, :attr:`position_dop`,
+    :attr:`velocity_ned`) are what a receiver reports about the solution itself rather than
+    the position it produced. They are what distinguishes a measured fix from one the
+    receiver is extrapolating, which NavSatFix alone cannot express: entering a tunnel the
+    status and covariance can stay unchanged for seconds while the satellite count is
+    already falling. They are None for receivers or datasets that do not report them.
     """
 
     __slots__ = (
@@ -117,6 +137,12 @@ class Gnss(BaseModality):
         "_position_covariance_type",
         "_status",
         "_service",
+        "_num_satellites",
+        "_fix_type",
+        "_horizontal_accuracy",
+        "_vertical_accuracy",
+        "_position_dop",
+        "_velocity_ned",
     )
 
     def __init__(
@@ -130,6 +156,12 @@ class Gnss(BaseModality):
         position_covariance_type: Optional[int] = None,
         status: Optional[int] = None,
         service: Optional[int] = None,
+        num_satellites: Optional[int] = None,
+        fix_type: Optional[int] = None,
+        horizontal_accuracy: Optional[float] = None,
+        vertical_accuracy: Optional[float] = None,
+        position_dop: Optional[float] = None,
+        velocity_ned: Optional[npt.NDArray[np.float64]] = None,
     ) -> None:
         """Initialize a GNSS fix.
 
@@ -142,6 +174,13 @@ class Gnss(BaseModality):
         :param position_covariance_type: Optional NavSatFix covariance type constant.
         :param status: Optional NavSatStatus fix status constant.
         :param service: Optional NavSatStatus service bitmask.
+        :param num_satellites: Optional number of satellites used in the solution.
+        :param fix_type: Optional receiver fix type (0 none, 2 2D, 3 3D, higher values are
+            receiver specific, e.g. 4 GNSS + dead reckoning).
+        :param horizontal_accuracy: Optional reported 1-sigma horizontal accuracy in meters.
+        :param vertical_accuracy: Optional reported 1-sigma vertical accuracy in meters.
+        :param position_dop: Optional position dilution of precision.
+        :param velocity_ned: Optional (north, east, down) velocity in m/s.
         """
         self._timestamp = timestamp
         self._metadata = metadata
@@ -152,6 +191,12 @@ class Gnss(BaseModality):
         self._position_covariance_type = position_covariance_type
         self._status = status
         self._service = service
+        self._num_satellites = num_satellites
+        self._fix_type = fix_type
+        self._horizontal_accuracy = horizontal_accuracy
+        self._vertical_accuracy = vertical_accuracy
+        self._position_dop = position_dop
+        self._velocity_ned = velocity_ned
 
     @property
     def timestamp(self) -> Timestamp:
@@ -202,3 +247,40 @@ class Gnss(BaseModality):
     def service(self) -> Optional[int]:
         """NavSatStatus service bitmask, or None if not provided."""
         return self._service
+
+    @property
+    def num_satellites(self) -> Optional[int]:
+        """Number of satellites used in the solution, or None if not reported."""
+        return self._num_satellites
+
+    @property
+    def fix_type(self) -> Optional[int]:
+        """Receiver fix type (0 none, 2 2D, 3 3D, higher receiver specific), or None if not reported."""
+        return self._fix_type
+
+    @property
+    def horizontal_accuracy(self) -> Optional[float]:
+        """Reported 1-sigma horizontal accuracy in meters, or None if not reported."""
+        return self._horizontal_accuracy
+
+    @property
+    def vertical_accuracy(self) -> Optional[float]:
+        """Reported 1-sigma vertical accuracy in meters, or None if not reported."""
+        return self._vertical_accuracy
+
+    @property
+    def position_dop(self) -> Optional[float]:
+        """Position dilution of precision, or None if not reported."""
+        return self._position_dop
+
+    @property
+    def velocity_ned(self) -> Optional[npt.NDArray[np.float64]]:
+        """(north, east, down) velocity in m/s as a (3,) array, or None if not reported."""
+        return self._velocity_ned
+
+    @property
+    def ground_speed(self) -> Optional[float]:
+        """Horizontal speed over ground in m/s from :attr:`velocity_ned`, or None if not reported."""
+        if self._velocity_ned is None:
+            return None
+        return float(np.hypot(self._velocity_ned[0], self._velocity_ned[1]))

--- a/tests/unit/datatypes/sensors/test_imu_gnss.py
+++ b/tests/unit/datatypes/sensors/test_imu_gnss.py
@@ -153,10 +153,78 @@ class TestGnssArrowRoundTrip:
         assert bare_fix.status is None
         assert bare_fix.position_covariance is None
 
+        # Without has_solution_quality the columns do not exist and the fields read back None.
+        assert f"{metadata.modality_key}.num_satellites" not in table.column_names
+        assert full_fix.num_satellites is None
+        assert full_fix.ground_speed is None
+
+    def test_gnss_round_trip_with_solution_quality(self):
+        log_dir = Path(tempfile.mkdtemp())
+        metadata = GnssMetadata(gnss_name="ublox", has_solution_quality=True)
+        writer = ArrowGnssWriter(log_dir, metadata)
+        writer.write_modality(
+            Gnss(
+                timestamp=Timestamp.from_us(7),
+                metadata=metadata,
+                latitude=49.02037,
+                longitude=8.43765,
+                altitude=162.41,
+                status=1,
+                num_satellites=17,
+                fix_type=3,
+                horizontal_accuracy=1.43,
+                vertical_accuracy=2.10,
+                position_dop=1.45,
+                velocity_ned=np.array([1.039, -0.220, 0.076]),
+            )
+        )
+        # A fix whose solution-quality fields are missing, e.g. no PVT message nearby.
+        writer.write_modality(
+            Gnss(timestamp=Timestamp.from_us(8), metadata=metadata, latitude=49.02038, longitude=8.43766, altitude=1.0)
+        )
+        writer.close()
+
+        table = _read_table(log_dir / "gnss.arrow")
+        restored_metadata = get_metadata_from_arrow_schema(table.schema, GnssMetadata)
+        assert restored_metadata.has_solution_quality
+
+        fix = ArrowGnssReader.read_at_index(0, table, restored_metadata, dataset="test")
+        assert fix.num_satellites == 17
+        assert fix.fix_type == 3
+        assert fix.horizontal_accuracy == pytest.approx(1.43)
+        assert fix.vertical_accuracy == pytest.approx(2.10)
+        assert fix.position_dop == pytest.approx(1.45)
+        np.testing.assert_allclose(fix.velocity_ned, [1.039, -0.220, 0.076])
+        assert fix.ground_speed == pytest.approx(1.062, abs=1e-3)
+
+        unmatched = ArrowGnssReader.read_at_index(1, table, restored_metadata, dataset="test")
+        assert unmatched.num_satellites is None
+        assert unmatched.velocity_ned is None
+        assert unmatched.ground_speed is None
+
+    def test_gnss_solution_quality_dropped_without_flag(self):
+        """A fix carrying quality fields must not be written silently when the flag is off."""
+        log_dir = Path(tempfile.mkdtemp())
+        metadata = GnssMetadata(gnss_name="ublox")
+        writer = ArrowGnssWriter(log_dir, metadata)
+        with pytest.raises(AssertionError, match="has_solution_quality"):
+            writer.write_modality(
+                Gnss(
+                    timestamp=Timestamp.from_us(7),
+                    metadata=metadata,
+                    latitude=49.0,
+                    longitude=8.4,
+                    altitude=162.0,
+                    num_satellites=17,
+                )
+            )
+        writer.close()
+
     def test_gnss_metadata_without_datum(self):
         metadata = GnssMetadata(gnss_name="ublox")
         restored = GnssMetadata.from_dict(metadata.to_dict())
         assert restored.datum_lla is None
+        assert restored.has_solution_quality is False
         assert restored.gnss_name == "ublox"
 
 


### PR DESCRIPTION
## What

Adds optional ublox solution-quality fields to `Gnss`: satellite count, fix type, reported
horizontal/vertical accuracy, PDOP and NED velocity, plus a derived `ground_speed` that
matches the receiver's own `gSpeed`.

## Why

`NavSatFix` cannot distinguish a measured fix from one the receiver is extrapolating.
Entering a tunnel, its status and covariance stay unchanged for several seconds while the
satellite count is already falling, so downstream consumers cannot tell when a position
stopped being real.

## Backward compatibility

The columns are written only when `GnssMetadata.has_solution_quality` is set, following the
existing IMU pattern. Logs converted without them keep their schema, still load, and report
the new fields as `None`. The flag is read with a default so older metadata blobs continue
to deserialize. Writing a fix with quality fields while the flag is off now asserts instead
of silently dropping them.

## Testing

Full suite green: 1960 passed, plus 3 new GNSS tests. Verified end to end by converting
`20260806_105951`: 304 PVT messages joined onto 1520 fixes, all 12 columns present,
satellite count 0-27, hAcc 0.21-73.05 m.

## Notes for review

- Base is `feat/kesai-camera-metadata-radar-viz`, not `main` — that branch carries
  `display_isp`, which the consumer in `py123d-dev` imports. A branch off `main` would not run.
- The counterpart is already on `py123d-dev` `main` (`kesai_parser.py` reads `/ubx_nav_pvt`
  and sets the flag), so `py123d-dev` main currently requires this branch to be checked out
  alongside it.

Co-authored with Claude Opus 5.
