### PR TITLE
Align target duration time with nuplan default duration time

### DIFF
--- a/src/py123d/parser/nuplan/nuplan_parser.py
+++ b/src/py123d/parser/nuplan/nuplan_parser.py
@@ -88,7 +88,7 @@ NUPLAN_CAMERA_MAPPING = {
     CameraID.PCAM_R2: CameraChannel.CAM_R2,
 }
 
-TARGET_DT: Final[float] = 0.1  # TODO: make configurable
+TARGET_DT: Final[float] = 0.05  # TODO: make configurable
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
problem:
- Some `navsim`/`openscene` logs contain tokens with timestamps which do not overlap with the `nuplan` `sync.arrow` file when using the default settings. Example: log `2021.06.08.14.35.24_veh-26_02555_03004` of the `mini` split.
- root cause: The mismatch between `TARGET_DT` [here](https://github.com/kesai-labs/py123d/blob/97d61fa024dd6dcf503f06f25fe01808f9c6fe46/src/py123d/parser/nuplan/nuplan_parser.py#L91) and `NUPLAN_DEFAULT_DT` [here](https://github.com/kesai-labs/py123d/blob/97d61fa024dd6dcf503f06f25fe01808f9c6fe46/src/py123d/parser/nuplan/utils/nuplan_constants.py#L13) combined with the computation of an offset [here](https://github.com/kesai-labs/py123d/blob/97d61fa024dd6dcf503f06f25fe01808f9c6fe46/src/py123d/parser/nuplan/nuplan_parser.py#L310) yields to a suboptimal sampling for matching `navsim`/`openscene` logs to the `nuplan` `sync.arrow` file.

easy fix:
- Change `TARGET_DT` from `0.1` to `0.05`, aligning it to `NUPLAN_DEFAULT_DT` and forcing it to sweep through all lidar pc reference rows.

proper fix:
- Make `TARGET_DT` configurable.